### PR TITLE
Adjust requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Sphinx==1.6.7
+ipython==5.7.0
+Sphinx==1.7.5
 sphinx_rtd_theme


### PR DESCRIPTION
Add Ipython, needed to run the tests. Bump to the more recent
stable release of Sphinx.