### PR TITLE
Use the template "Inline Code" always

### DIFF
--- a/engine/sphinx/widget_extension.py
+++ b/engine/sphinx/widget_extension.py
@@ -23,7 +23,7 @@ WIDGETS_SERVER_URL = "https://cloudchecker-staging.r53.adacore.com"
 # TODO: make this a configuration parameter
 
 template = u"""
-<div example_editor="{editor_base}"
+<div example_editor="Inline Code"
      example_server="{server_url}"
      {extra_attribs}
      inline="true">
@@ -189,8 +189,6 @@ class WidgetCodeDirective(Directive):
             print files
             raise
 
-        editor_base = "Ada Main" if has_run_button else "SPARK Main"
-
         for arg in ALLOWED_EXTRA_ARGS:
             if arg in argument_list:
                 extra_attribs += ' extra_args="{}"'.format(arg)
@@ -205,7 +203,6 @@ class WidgetCodeDirective(Directive):
                       template.format(server_url=WIDGETS_SERVER_URL,
                                       files_divs=divs,
                                       shadow_files_divs=shadow_files_divs,
-                                      editor_base=editor_base,
                                       extra_attribs=extra_attribs),
                       format='html')
         ]


### PR DESCRIPTION
This is the template that accepts all configurations of
with or without SPARK and with or without a main.