### PR TITLE
Editorial change: removed ReST class due to dependency

### DIFF
--- a/courses/intro-to-ada/chapters/exceptions.rst
+++ b/courses/intro-to-ada/chapters/exceptions.rst
@@ -25,7 +25,6 @@ peculiar to you if you're used to the way Java or Python support
 exceptions. Here's how you declare an exception:
 
 .. code:: ada no_button
-    :class: ada-syntax-only
 
     package Exceptions is
         My_Except : exception;


### PR DESCRIPTION
This was actually already fixed in a previous commit (IDs:
d40678d94ac5bee67feae9cd977fc2ace2c55005,
53e3d2d51622459617f7694dadd050e8f933736d)

https://github.com/AdaCore/learn/pull/55