### PR TITLE
Disable sticky_navigation

### DIFF
--- a/engine/sphinx/conf.py
+++ b/engine/sphinx/conf.py
@@ -103,7 +103,8 @@ html_theme_path = ['.'] # make sphinx search for themes in current dir
 # documentation.
 #
 html_theme_options = {
-    "beta": True
+    "beta": True,
+    'sticky_navigation': False,
 }
 
 html_logo = "learn_theme/static/img/logo.svg"


### PR DESCRIPTION
That way the sidebar doesn't scroll together with the content, and the
logo & search bar stays visible