### PR TITLE
Reset lines already read when launching an operation

### DIFF
--- a/engine/sphinx/learn_theme/static/js/editors.js
+++ b/engine/sphinx/learn_theme/static/js/editors.js
@@ -183,8 +183,8 @@ function query_operation_result(container, example_name, editors, output_area, o
         })
         .done(function (json) {
             if (json.identifier == "") {
-                reset(container, editors)
-                output_error(output_area, json.message)
+                reset(container, editors);
+                output_error(output_area, json.message);
             } else {
                 get_output_from_identifier(container, editors, output_area, json.identifier)
             }

--- a/engine/sphinx/learn_theme/static/js/editors.js
+++ b/engine/sphinx/learn_theme/static/js/editors.js
@@ -169,6 +169,8 @@ function query_operation_result(container, example_name, editors, output_area, o
         "extra_args": container.attr("extra_args"),
     }
 
+    // reset the number of lines already read
+    container.already_read = 0;
 
     // request the examples
     $.ajax({


### PR DESCRIPTION
This fixes an issue where relaunching an operation after
an error causes some lines to be ignored in the new run.