### PR TITLE
Travis-CI: deactivating git submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ cache:
   - $HOME/build_tools
   - $HOME/.cache/pip
 
+git:
+  submodules:
+    false
+
 before_install:
  - "sudo apt-get install graphviz"
 


### PR DESCRIPTION
Due to Sphinx warning from 'ace-builds' module.