### PR TITLE
Using widget for 'ada-nocheck' and 'ada-syntax-only' classes

### DIFF
--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/02_program_consistency.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/02_program_consistency.rst
@@ -60,8 +60,7 @@ of context instead of textual inclusion of content, using ``with`` clauses:
 In particular, ``with`` clauses are only allowed at the beginning of files, and
 the compiler issues an error if they are used elsewhere:
 
-.. code:: ada
-    :class: ada-nocheck
+.. code-block:: ada
 
     procedure Hello_World is
          with Ada.Text_IO;

--- a/courses/intro-to-spark/book/05_Proof_Of_Functional_Correctness.rst
+++ b/courses/intro-to-spark/book/05_Proof_Of_Functional_Correctness.rst
@@ -714,8 +714,7 @@ into several acyclic parts.
 
 As an example, let's look at a simple loop with an exit condition.
 
-.. code:: ada
-    :class: ada-nocheck
+.. code-block:: ada
 
     Stmt1;
     loop

--- a/engine/sphinx/widget_extension.py
+++ b/engine/sphinx/widget_extension.py
@@ -147,7 +147,10 @@ class WidgetCodeDirective(Directive):
         if self.arguments:
             argument_list = self.arguments[0].split(' ')
 
-        if 'no_button' in argument_list:
+        if 'no_button' in argument_list or (
+            'class' in self.options and (
+                'ada-nocheck' in self.options['class'] or
+                'ada-syntax-only' in self.options['class'])):
             has_run_button = False
             has_prove_button = False
         else:
@@ -160,18 +163,10 @@ class WidgetCodeDirective(Directive):
             print (self.lineno, dir(self))
             raise self.error("you need to add a :code-config: role")
 
-        if 'class' in self.options and (
-                'ada-nocheck' in self.options['class'] or
-                'ada-syntax-only' in self.options['class']):
-            # TODO: display it in an editor with no buttons
-            return [nodes.raw('',
-                              '<pre>{}</pre>'.format('\n'.join(self.content)),
-                              format='html')]
-        else:
-            try:
-                files = real_gnatchop(self.content)
-            except subprocess.CalledProcessError:
-                raise self.error("could not gnatchop example")
+        try:
+            files = real_gnatchop(self.content)
+        except subprocess.CalledProcessError:
+            raise self.error("could not gnatchop example")
 
         if config.accumulate_code:
             # We are accumulating code: store the new code in the


### PR DESCRIPTION
Getting rid of raw HTML ('pre') output.
Corrected two source-code blocks.
Fixed issue #163.
