### PR TITLE
Minor adjustments, useful for the development environment

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -57,6 +57,13 @@ publish-staging:
 	cd ../; \
 	rm -rf learn-staging-html-pages
 
+# Development target, rebuilds the site, with it pointing to the local
+# code server.
+local:
+	rm -rf "$(BUILDDIR)"
+	CODE_SERVER_URL="Http://localhost:8000" $(SPHINXBUILD) -M html "../" \
+	"$(BUILDDIR)" $(SPHINXOPTS) $(O) -v -c "$(SPHINXCONF)"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/engine/sphinx/conf.py
+++ b/engine/sphinx/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = u'learn.adacore.com'
-copyright = u'2018, AdaCore'
+copyright = u'2019, AdaCore'
 author = u'AdaCore'
 
 # The short X.Y version

--- a/engine/sphinx/widget_extension.py
+++ b/engine/sphinx/widget_extension.py
@@ -30,8 +30,9 @@ from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from xml.sax.saxutils import escape
 
-WIDGETS_SERVER_URL = "https://cloudchecker-staging.r53.adacore.com"
-# TODO: make this a configuration parameter
+WIDGETS_SERVER_URL = os.environ.get(
+    "CODE_SERVER_URL",
+    "https://cloudchecker-staging.r53.adacore.com")
 
 template = u"""
 <div class="widget_editor"


### PR DESCRIPTION
Bump the copyright year, make the URL of the code server
read an environment variable, and add a Makefile target
for regenerating a build of the site pointing to a local
code server.