### PR TITLE
Minor CSS fixes

### DIFF
--- a/engine/sphinx/learn_theme/static/css/common.css
+++ b/engine/sphinx/learn_theme/static/css/common.css
@@ -5,7 +5,7 @@ div.file{
 div.editor_container{
    height: 30em;
    border: 1px solid #ddd;
-   border-top: 0px;
+   margin: 5px 0px;
 }
 
 div.editor_container.inline{
@@ -71,7 +71,6 @@ div.output_success{
 
 div.output_area{
    font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
-   margin-top: 10px;
    background: #f3f3f3;
 }
 
@@ -82,6 +81,7 @@ div.output_row{
 div.output_row button{
    margin-right:4px;
    margin-top:2px;
+   margin-bottom: 4px;
 }
 
 .read-only {


### PR DESCRIPTION
Rearrange margins around containers so that highlight boxes
don't have a blank space at the bottom.

Re-add top borders to the editors.