### PR TITLE
Various fixes on the interactive snippets

### DIFF
--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
@@ -182,7 +182,7 @@ Here is the output of AdaCore's GNAT compiler:
 The correct version of ``Swap`` in SPARK takes parameters of mode `in out`:
 
 .. code:: ada
-   :class: ada-syntax-only
+    :class: ada-syntax-only
 
     procedure Swap (X, Y : in out Integer) is
        Tmp : constant Integer := X;
@@ -247,7 +247,7 @@ statements have explicit begin and end markers, which prevents mistakes
 that are possible in C. The SPARK (also Ada) version of the above C code is as follows:
 
 .. code:: ada
-   :class: ada-syntax-only
+    :class: ada-syntax-only
 
     function Func return Integer is
     begin
@@ -333,7 +333,7 @@ useless in ``Opposite`` and ``Multiply``, as all ``Sign`` values are covered.
 Here is a correct version of the same code:
 
 .. code:: ada
-   :class: ada-syntax-only
+    :class: ada-syntax-only
 
     package Sign_Domain is
 
@@ -512,7 +512,7 @@ In SPARK (as in Ada), each if-statement has a matching end marker ``end if;``
 so the dangling-else problem cannot arise. The above C code is written as follows:
 
 .. code:: ada prove_button
-   :class: ada-syntax-only
+    :class: ada-syntax-only
 
     function Absval (X : Integer) return Integer is
        Result : Integer := X;

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
@@ -182,6 +182,7 @@ Here is the output of AdaCore's GNAT compiler:
 The correct version of ``Swap`` in SPARK takes parameters of mode `in out`:
 
 .. code:: ada
+   :class: ada-syntax-only
 
     procedure Swap (X, Y : in out Integer) is
        Tmp : constant Integer := X;
@@ -246,6 +247,7 @@ statements have explicit begin and end markers, which prevents mistakes
 that are possible in C. The SPARK (also Ada) version of the above C code is as follows:
 
 .. code:: ada
+   :class: ada-syntax-only
 
     function Func return Integer is
     begin
@@ -331,6 +333,7 @@ useless in ``Opposite`` and ``Multiply``, as all ``Sign`` values are covered.
 Here is a correct version of the same code:
 
 .. code:: ada
+   :class: ada-syntax-only
 
     package Sign_Domain is
 
@@ -509,6 +512,7 @@ In SPARK (as in Ada), each if-statement has a matching end marker ``end if;``
 so the dangling-else problem cannot arise. The above C code is written as follows:
 
 .. code:: ada prove_button
+   :class: ada-syntax-only
 
     function Absval (X : Integer) return Integer is
        Result : Integer := X;

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
@@ -615,7 +615,7 @@ the left operand and only evaluate the right operand when its value may affect
 the result.
 
 .. code:: ada
-   :class: ada-expect-compile-error
+    :class: ada-expect-compile-error
 
     package Bad_Hamlet is
        type Animal is (Ape, Bee, Cat);
@@ -676,7 +676,7 @@ in legal SPARK (or Ada), then the following approach will work (the type ``Unsig
 is an 8-bit modular type declared in the predefined package ``Interfaces``).
 
 .. code:: ada
-   :class: ada-syntax-only
+    :class: ada-syntax-only
 
     with Interfaces; use Interfaces;
     package Unethical_Genetics is

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
@@ -284,7 +284,7 @@ than the length of parameter ``P`` by stating this property in the postcondition
 
 :code-config:`run_button=False;prove_button=False;accumulate_code=False`
 
-.. code:: ada prove_button
+.. code:: ada prove_report_all_button
 
     package Types is
        type Int_Array is array (Positive range <>) of Integer;
@@ -664,7 +664,7 @@ and ``Rotate_Right``:
 
    package Bad_Genetics is
       type Animal is (Ape, Bee, Cat, Dog);
-      Mutant : Animal := Bee xor Dog; -- Error
+      Mutant : Animal := Bee xor Dog;  --  ERROR
       pragma Assert (Mutant = Cat);
    end Bad_Genetics;
 
@@ -676,6 +676,7 @@ in legal SPARK (or Ada), then the following approach will work (the type ``Unsig
 is an 8-bit modular type declared in the predefined package ``Interfaces``).
 
 .. code:: ada
+   :class: ada-syntax-only
 
     with Interfaces; use Interfaces;
     package Unethical_Genetics is
@@ -791,12 +792,12 @@ different types.
        B : Boolean := True;
        C : Character := 'a';
     begin
-       F := I; -- Illegal
-       I := A; -- Illegal
-       A := B; -- Illegal
-       M := A; -- Illegal
-       B := C; -- Illegal
-       C := F; -- Illegal
+       F := I;  --  ERROR
+       I := A;  --  ERROR
+       A := B;  --  ERROR
+       M := A;  --  ERROR
+       B := C;  --  ERROR
+       C := F;  --  ERROR
     end Bad_Conversions;
 
 The compiler reports a mismatch on every statement in the above procedure
@@ -820,12 +821,12 @@ type and its parent typ, but all other conversions are illegal:
        B : Boolean := True;
        C : Character := 'a';
     begin
-       F := Float (I);      -- Legal
-       I := Integer (A);    -- Illegal
-       A := Animal (B);     -- Illegal
-       M := My_Animal (A);  -- Legal
-       B := Boolean (C);    -- Illegal
-       C := Character (F);  -- Illegal
+       F := Float (I);       --  OK
+       I := Integer (A);     --  ERROR
+       A := Animal (B);      --  ERROR
+       M := My_Animal (A);   --  OK
+       B := Boolean (C);     --  ERROR
+       C := Character (F);   --  ERROR
     end Bad_Conversions;
 
 Although an enumeration value cannot be converted to an integer (or *vice

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/05_initialization.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/05_initialization.rst
@@ -300,7 +300,7 @@ errors, both for records:
        type Rec is record
           X, Y, Z : Integer;
        end record;
-       R : Rec := (X => 1); -- Error, Y and Z not specified
+       R : Rec := (X => 1);  --  ERROR, Y and Z not specified
     end Init_Record;
 
 and for arrays:
@@ -309,7 +309,7 @@ and for arrays:
 
     package Init_Array is
        type Arr is array (1 .. 10) of Integer;
-       A : Arr := (1 => 1); -- Error, elements 2..10 not specified
+       A : Arr := (1 => 1);  --  ERROR, elements 2..10 not specified
     end Init_Array;
 
 Similarly, redundant initialization leads to compilation errors for records:
@@ -321,7 +321,7 @@ Similarly, redundant initialization leads to compilation errors for records:
        type Rec is record
           X, Y, Z : Integer;
        end record;
-       R : Rec := (X => 1, Y => 1, Z => 1, X => 2); -- Error, X duplicated
+       R : Rec := (X => 1, Y => 1, Z => 1, X => 2);  --  ERROR, X duplicated
     end Init_Record;
 
 and for arrays:
@@ -331,7 +331,7 @@ and for arrays:
 
     package Init_Array is
        type Arr is array (1 .. 10) of Integer;
-       A : Arr := (1 .. 8 => 1, 9 .. 10 => 2, 7 => 3); -- error, A(7) duplicated
+       A : Arr := (1 .. 8 => 1, 9 .. 10 => 2, 7 => 3);  --  ERROR, A(7) duplicated
     end Init_Array;
 
 Finally, while it is legal in Ada to leave uninitialized parts in a record or
@@ -346,7 +346,7 @@ initialized, both for records:
        type Rec is record
           X, Y, Z : Integer;
        end record;
-       R : Rec := (X => 1, others => <>); -- Error, Y and Z not specified
+       R : Rec := (X => 1, others => <>);  --  ERROR, Y and Z not specified
     end Init_Record;
 
 and for arrays:
@@ -355,5 +355,5 @@ and for arrays:
 
     package Init_Array is
        type Arr is array (1 .. 10) of Integer;
-       A : Arr := (1 .. 8 => 1, 9 .. 10 => <>); -- Error, A(9..10) not specified
+       A : Arr := (1 .. 8 => 1, 9 .. 10 => <>);  --  ERROR, A(9..10) not specified
     end Init_Array;

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/06_side_effects.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/06_side_effects.rst
@@ -148,7 +148,7 @@ statement level, so the following is not allowed:
     package body Volatile_Read is
        procedure P (Y : out Integer) is
        begin
-          Y := X - X; -- Not legal SPARK
+          Y := X - X;  --  ERROR
        end P;
     end Volatile_Read;
 
@@ -185,7 +185,7 @@ parameters:
 .. code:: ada prove_flow_button
 
    function Bad_Function (X, Y : Integer; Sum, Max : out Integer) return Boolean;
-   --  Not legal SPARK, since "out" parameters are not allowed
+   --  ERROR, since "out" parameters are not allowed
 
 More generally, SPARK does not allow functions that have a side effect
 in addition to returning their result, as is typical of many idioms in other
@@ -205,7 +205,7 @@ languages, for example when setting a new value and returning the previous one:
        function Set (V : Integer) return Integer is
           Previous : constant Integer := Value;
        begin
-          Value := V;  -- Not legal SPARK
+          Value := V;  --  ERROR
           return Previous;
        end Set;
 

--- a/books/SPARK_for_the_MISRA_C_Developer/chapters/07_undefined_behavior.rst
+++ b/books/SPARK_for_the_MISRA_C_Developer/chapters/07_undefined_behavior.rst
@@ -220,7 +220,7 @@ errors entails:
 For example, here is a revised version of the previous example, which
 can guarantee through proof that no possible run-time error can be raised:
 
-.. code:: ada prove_button
+.. code:: ada prove_report_all_button
 
     package No_Runtime_Errors is
 


### PR DESCRIPTION
Add qualifier ada-syntax-only when no main is provided.

Add parameter prove_report_all_button when we'd like the messages about
proved checks.

Uniformly use ERROR in comments to signal violations of Ada or SPARK rules.