### PR TITLE
Restore prove buttons in SPARK intro course

### DIFF
--- a/courses/intro-to-spark/book/01_Overview.rst
+++ b/courses/intro-to-spark/book/01_Overview.rst
@@ -162,7 +162,7 @@ The SPARK language doesn't allow side-effects in expressions.  In other
 words, evaluating a SPARK expression must not update any object. This
 limitation is necessary to avoid unpredictable behavior that depends on
 order of evaluation, parameter passing mechanisms, or compiler
-optimizations. The expression for ``G`` below is non-deterministic due to
+optimizations. The expression for ``Dummy`` below is non-deterministic due to
 the order in which the two calls to F are evaluated.  It's therefore not
 legal SPARK.
 
@@ -178,10 +178,10 @@ legal SPARK.
           return Tmp;
        end F;
 
-       G : Integer := 0;
+       Dummy : Integer := 0;
 
     begin
-       G := F (G) - F (G); -- ??
+       Dummy := F (Dummy) - F (Dummy); -- ??
     end Show_Illegal_Ada_Code;
 
 In fact, the code above is not even legal Ada, so the same error is
@@ -193,17 +193,17 @@ Ada compiler:
 
     procedure Show_Illegal_SPARK_Code is
 
-       G : Integer := 0;
+       Dummy : Integer := 0;
 
        function F return Integer is
-          Tmp : constant Integer := G;
+          Tmp : constant Integer := Dummy;
        begin
-          G := G + 1;
+          Dummy := Dummy + 1;
           return Tmp;
        end F;
 
     begin
-       G := F - F; -- ??
+       Dummy := F - F; -- ??
     end Show_Illegal_SPARK_Code;
 
 The SPARK languages enforces the lack of side-effects in expressions by

--- a/courses/intro-to-spark/book/03_Proof_Of_Program_Integrity.rst
+++ b/courses/intro-to-spark/book/03_Proof_Of_Program_Integrity.rst
@@ -32,7 +32,7 @@ below illustrates many examples of possible runtime errors, all within a
 single statement.  Look at the assignment statement setting the ``I`` +
 ``J``'th cell of an array ``A`` to the value ``P`` / ``Q``.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Show_Runtime_Errors is
 
@@ -174,7 +174,7 @@ that the value of ``X`` after the call is always less than
 :ada:`Integer'Last`. Therefore, it can't prove that the addition following
 the call to ``Increment`` can't overflow.
 
-.. code:: ada spark-report-all
+.. code:: ada prove_report_all_button
 
     procedure Show_Modularity is
 
@@ -268,7 +268,7 @@ with assertions enabled and testing it with inputs that trigger the
 violation. Another way, one that doesn't require guessing the needed
 inputs, is to run GNATprove.
 
-.. code:: ada run_button
+.. code:: ada run_button prove_button
    :class: ada-run-expect-failure
 
     procedure Show_Precondition_Violation is
@@ -293,7 +293,7 @@ inputs that trigger the violation. Another way, one which again doesn't
 require finding the inputs needed to demonstrate the error, is to run
 GNATprove.
 
-.. code:: ada run_button
+.. code:: ada run_button prove_button
    :class: ada-run-expect-failure
 
     procedure Show_Postcondition_Violation is
@@ -342,7 +342,7 @@ those semantics too heavy, in particular with respect to overflow checks,
 because they can make it harder to specify an appropriate precondition.  We
 see this in the function ``Add`` below.
 
-.. code:: ada run_button
+.. code:: ada run_button prove_button
    :class: ada-run-expect-failure
 
     procedure Show_Executable_Semantics
@@ -454,7 +454,7 @@ the specification may be incorrect. As an example, there's an error in our
 procedure ``Incr_Until`` below which makes its :ada:`Contract_Cases`
 unprovable.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Show_Failed_Proof_Attempt is
 
@@ -487,7 +487,7 @@ sets of inputs. This allows you to find bugs in both the code and its
 contracts. In this case, testing ``Incr_Until`` with an input greater than
 1000 raises an exception at runtime.
 
-.. code:: ada run_button
+.. code:: ada run_button prove_button
    :class: ada-run-expect-failure
 
     package Show_Failed_Proof_Attempt is
@@ -555,7 +555,7 @@ Let's look at the case where the code and the specification are correct but
 there's some information missing. As an example, GNATprove finds the
 postcondition of ``Increase`` to be unprovable.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Show_Failed_Proof_Attempt is
 
@@ -619,7 +619,7 @@ For example, the postcondition of our ``GCD`` function below --- which
 calculates the value of the ``GCD`` of two positive numbers using Euclide's
 algorithm --- can't be verified with GNATprove's default settings.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Show_Failed_Proof_Attempt is
 
@@ -715,7 +715,7 @@ The package ``Lists`` defines a linked-list data structure.  We call
 index ``J``. The postcondition of ``Link`` uses ``Goes_To`` to state that
 there must be a link between its arguments once ``Link`` completes.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Lists with SPARK_Mode is
 
@@ -821,7 +821,7 @@ procedure that adds an element at the top of the stack and a function
 ``Peek`` that returns the content of the element at the top of the stack
 (without removing it).
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Stacks with SPARK_Mode is
 
@@ -871,7 +871,7 @@ Example #4
 We now change the behavior of ``Push`` so it raises an exception when the
 stack is full instead of returning.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Stacks with SPARK_Mode is
 
@@ -981,7 +981,7 @@ to one data element.  The procedure ``Read_Record`` reads two pieces of
 data starting at index ``From`` out of the chunk represented by the value
 of ``Memory``.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Memories is
 
@@ -1028,7 +1028,7 @@ Example #7
 
 Let's rewrite the precondition of ``Read_One`` to avoid any possible overflow.
 
-.. code:: ada
+.. code:: ada prove_button
 
     package Memories is
 
@@ -1126,7 +1126,7 @@ The procedure ``Compute`` performs various computations on its argument.
 The computation performed depends on its input range and is reflected in
 its contract, which we express using a ``Contract_Cases`` aspect.
 
-.. code:: ada
+.. code:: ada prove_button
 
     procedure Compute (X : in out Integer) with
       Contract_Cases => ((X in -100 .. 100) => X = X'Old * 2,
@@ -1161,7 +1161,7 @@ Example #10
 
 Let's rewrite the contract of ``Compute`` to avoid overlapping cases.
 
-.. code:: ada
+.. code:: ada prove_button
 
     procedure Compute (X : in out Integer) with
       Contract_Cases => ((X in    1 ..  199) => X >= X'Old,

--- a/courses/intro-to-spark/book/04_State_Abstraction.rst
+++ b/courses/intro-to-spark/book/04_State_Abstraction.rst
@@ -45,7 +45,7 @@ implementation.
 
 Take a look at the example code shown below.
 
-.. code:: ada prove_button
+.. code:: ada prove_report_all_button
 
     procedure Increase (X : in out Integer) with
       Global => null,
@@ -60,7 +60,7 @@ Take a look at the example code shown below.
 We've written a specification of the subprogram ``Increase`` to say that it's
 called with a single argument, a variable of type :ada:`Integer` whose
 initial value is less than 100. Our contract says that the only effect of
-the subproram is to increase the value of its argument.
+the subprogram is to increase the value of its argument.
 
 
 Why is Abstraction Useful?

--- a/courses/intro-to-spark/book/05_Proof_Of_Functional_Correctness.rst
+++ b/courses/intro-to-spark/book/05_Proof_Of_Functional_Correctness.rst
@@ -119,8 +119,6 @@ called in that test, but just for that set.
 
 .. code:: ada prove_button run_button
 
-    with Ada.Text_IO; use Ada.Text_IO;
-
     package Show_Find is
 
        type Nat_Array is array (Positive range <>) of Natural;


### PR DESCRIPTION
Due to changes in the default used in the engine for the SPARK course, many
interactive snippets were missing a prove button. Now fixed.

Also fixes minor issues of parasitic warnings and less-than-ideal buttons.

Also modifies examples in reaction to improvements in flow analysis now
detecting correctly initialization of unconstrained array around loops.