### PR TITLE
Fixing issue #321

### DIFF
--- a/frontend/src/ts/widget.ts
+++ b/frontend/src/ts/widget.ts
@@ -364,15 +364,17 @@ export class Widget {
 
           // Lines that contain a sloc are clickable:
           div.on('click', () => {
-            this.editors.map((e) => {
-              if (basename == e.getResource().basename) {
-                // Switch to the tab that contains the editor
-                e.getTab().trigger('click');
+            if (window.getSelection().toString() == '') {
+              this.editors.map((e) => {
+                if (basename == e.getResource().basename) {
+                  // Switch to the tab that contains the editor
+                  e.getTab().trigger('click');
 
-                // Jump to the corresponding line
-                e.gotoLine(row, col);
-              }
-            });
+                  // Jump to the corresponding line
+                  e.gotoLine(row, col);
+                }
+              });
+            }
           });
         } else {
           homeArea.addLine(outMsg);


### PR DESCRIPTION
Fixing selection issue in output area. If text is selected, focus won't jump to the offending line in the editor. If nothing is selected, focus will jump as usual.