### PR TITLE
Fixing editor resize between tab changes

### DIFF
--- a/frontend/src/ts/components.ts
+++ b/frontend/src/ts/components.ts
@@ -4,12 +4,19 @@ export class Tabs {
   private contents: Array<JQuery> = [];
 
   /**
+   * The event callback signature for tabs
+   *
+   * @callback tabChange
+   */
+
+  /**
    * Add a Tab
    * @param {string} name - The name to put at the tab button
    * @param {JQuery} content - The content to put inside the tab
+   * @param {tabChange} fn - The function to call when the tab changes
    * @return {JQuery} The button or header for the new tab
    */
-  public addTab(name: string, content: JQuery): JQuery {
+  public addTab(name: string, content: JQuery, fn: () => void): JQuery {
     const tabContent = $('<div>')
         .addClass('tab-content')
         .append(content);
@@ -25,6 +32,8 @@ export class Tabs {
           for (const h of this.headers) {
             h.removeClass('active');
           }
+
+          fn();
 
           tabContent.addClass('active');
           tabContent.show();

--- a/frontend/src/ts/editor.ts
+++ b/frontend/src/ts/editor.ts
@@ -69,6 +69,26 @@ export class Editor {
   }
 
   /**
+   * Set the length of the visible lines in the editor
+   * @param {number} length - The number of visible lines in the editor
+   */
+  public setLength(length: number): void {
+    this.editor.setOption('minLines', length);
+    this.editor.resize();
+  }
+
+  /**
+   * Get the length of the visible lines in the editor
+   * @return {number} - The number of visible lines in the editor
+   */
+  public getLength(): number {
+    const maxLength = this.editor.getOption('maxLines');
+    const length = this.editor.session.doc.getLength();
+
+    return (length > maxLength) ? maxLength : length;
+  }
+
+  /**
    * Set the theme of the editor
    * @param {EditorTheme} theme - The ace theme to load
    */

--- a/frontend/src/ts/widget.ts
+++ b/frontend/src/ts/widget.ts
@@ -70,7 +70,12 @@ export class Widget {
       const ed = new Editor(file);
       this.editors.push(ed);
 
-      const tab = this.tabs.addTab(file.basename, ed.render());
+      const tab = this.tabs.addTab(file.basename, ed.render(), () => {
+        const lengths = this.editors.map((e) => e.getLength());
+        // This is a new one: ... is a spread operator
+        const max = Math.max(...lengths);
+        ed.setLength(max);
+      });
       ed.setTab(tab);
     });
 


### PR DESCRIPTION
Fixing useability issue when changing tabs in a widget. If editors were different sizes, changing tabs would cause the editor to shink or expand making it difficult to use. This fix will make the minimum size of each editor in the widget equal to the largest length editor in the grouping.