### PR TITLE
Use new compile_button that replaces class ada-syntax-only

### DIFF
--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/03_syntactic_guarantees.rst
@@ -249,7 +249,7 @@ above C code is as follows:
 
 :code-config:`run_button=False;prove_button=False;accumulate_code=False`
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     function Func return Integer is
     begin
@@ -338,7 +338,7 @@ Here is a correct version of the same code:
 
 :code-config:`run_button=False;prove_button=False;accumulate_code=False`
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     package Sign_Domain is
 

--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
@@ -673,7 +673,7 @@ is an 8-bit modular type declared in the predefined package :ada:`Interfaces`).
 
 :code-config:`run_button=False;prove_button=False;accumulate_code=False`
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     with Interfaces; use Interfaces;
     package Unethical_Genetics is

--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/05_initialization.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/05_initialization.rst
@@ -98,7 +98,7 @@ function :ada:`F` might not always initialize output parameter :ada:`P`:
 We can correct the program by initializing :ada:`P` to value 0 when condition :ada:`B` is
 not satisfied:
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     with Interfaces; use Interfaces;
 

--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/06_side_effects.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/06_side_effects.rst
@@ -151,7 +151,7 @@ statement level, so the following is not allowed:
 Instead, every read of a volatile variable must occur immediately before being
 assigned to another variable, as follows:
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     package Volatile_Read is
        X : Integer with Volatile;
@@ -213,7 +213,7 @@ GNATprove detects that function :ada:`Set` has a side effect on global variable
 :ada:`Value` and issues an error. The correct idiom in SPARK for such a case is to
 use a procedure with an :ada:`out` parameter to return the desired result:
 
-.. code:: ada prove_flow_report_all_button
+.. code:: ada prove_flow_report_all_button compile_button
 
     package Ok_Subprograms is
        procedure Set (V : Integer; Prev : out Integer);


### PR DESCRIPTION
Should use new feature from PR#334

It still seems there is no Examine(report=all) on all snippets that have
prove_flow_report_all_button, maybe due to the use of code-config above
with prove_button=False. To be sorted out.