### PR TITLE
Fixing publish Makefile target to include copy of pdf_books to target.

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -97,6 +97,7 @@ publish:
 	  rm -rf * && \
 	  git checkout CNAME ) && \
         cp -R $(BUILDDIR)/html/. learn-html-pages/ && \
+		cp -R $(BUILDDIR)/pdf_books learn-html-pages/ && \
         ( cd learn-html-pages && \
           git add -A && git commit -m "Regenerate" && git push origin gh-pages ) && \
         rm -rf learn-html-pages


### PR DESCRIPTION
The step to copy the generated pdf books to the publishing repo was missing from the publish Makefile target.