### PR TITLE
Editorial change: using LaTeX markup for separating authors.

### DIFF
--- a/content/courses/Ada_For_The_C_Embedded_Developer/conf.txt
+++ b/content/courses/Ada_For_The_C_Embedded_Developer/conf.txt
@@ -1,2 +1,2 @@
 title=Ada for the C Embedded Developer
-author=Quentin Ochem, Robert Tice, Gustavo A. Hoffmann, and Patrick Rogers.
+author=Quentin Ochem \\and Robert Tice \\and Gustavo A. Hoffmann \\and Patrick Rogers.

--- a/content/courses/intro-to-ada/conf.txt
+++ b/content/courses/intro-to-ada/conf.txt
@@ -1,3 +1,3 @@
 title=Introduction to Ada
-author=Raphaël Amiard and Gustavo A. Hoffmann
+author=Raphaël Amiard \\and Gustavo A. Hoffmann
 

--- a/content/courses/intro-to-spark/conf.txt
+++ b/content/courses/intro-to-spark/conf.txt
@@ -1,3 +1,3 @@
 title=Introduction to SPARK
-author=Claire Dross and Yannick Moy
+author=Claire Dross \\and Yannick Moy
 


### PR DESCRIPTION
- Using "\\and" markup as suggested in Sphinx documentation
  (https://www.sphinx-doc.org/en/2.0/usage/configuration.html)
- This change fixes #466.