### PR TITLE
Fixing download for widgets without a explicit specified main.

### DIFF
--- a/backend/app/widget/project.py
+++ b/backend/app/widget/project.py
@@ -143,7 +143,7 @@ class Project:
         self.gpr.insert_languages(languages)
 
         # Figure out which files are mains
-        if data['main']:
+        if 'main' in data.keys():
             self.main = data['main']
         else:
             mains = find_mains(self.file_list)


### PR DESCRIPTION
This was a backend error that assumed the the "main" key was explicitly added to every incoming request.