### PR TITLE
Solving remaining issues for PDF books.

### DIFF
--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
@@ -482,6 +482,8 @@ write a for loop:
         int vals[] = { 2, 2, 4, 4 };
 
         printf("Average: %d\n", average(vals, 4));
+
+        return 0;
     }
 
 [C]
@@ -509,6 +511,8 @@ write a for loop:
         int vals[] = { 2, 2, 4, 4 };
 
         printf("Average: %d\n", average(vals, 4));
+
+        return 0;
     }
 
 For the fun of it, let's also see the Ada way to do this:
@@ -917,6 +921,8 @@ Let's start with some syntax:
             }
             printf("sum = %d\n", sum);
         }
+
+        return 0;
     }
 
 [Ada]
@@ -1284,6 +1290,8 @@ following example:
     int main(int argc, const char * argv[])
     {
         weakTyping();
+
+        return 0;
     }
 
 Are the three programs above equivalent? It may seem like Ada is just adding
@@ -1432,6 +1440,8 @@ Ada enumerations work similarly to C :c:`enum`:
     int main(int argc, const char * argv[])
     {
         enum Day d = Monday;
+
+        return 0;
     }
 
 But even though such enumerations may be implemented by the compiler as numeric
@@ -1463,6 +1473,8 @@ original :c:`enum` declaration:
         enum Day d = Monday;
 
         printf("d = %d\n", d);
+
+        return 0;
     }
 
 But in Ada you must use both a type definition for :ada:`Day` as well as a
@@ -1698,6 +1710,8 @@ following declaration:
     {
         unsigned int x = 42;
         printf("x = %u\n", x);
+
+        return 0;
     }
 
 Another strategy is to declare subtypes for existing signed types and specify
@@ -1757,6 +1771,8 @@ consider this C example:
         /* Now: x == 0 */
 
         printf("x = %u\n", x);
+
+        return 0;
     }
 
 The corresponding code in Ada raises an exception:
@@ -1896,6 +1912,8 @@ equivalent in C:
         printf("%c", c);
         c++;
         printf("%c", c);
+
+        return 0;
     }
 
 Other interesting examples are the :ada:`'First` and :ada:`'Last` attributes
@@ -1954,6 +1972,8 @@ values from :ada:`'a'` to :ada:`'z'`:
             Arr [I] = C++;
             printf ("%c ", Arr [I]);
         }
+
+        return 0;
     }
 
 In C, only the size of the array is given during declaration. In Ada, array
@@ -2056,6 +2076,8 @@ the above behavior, actual pointer types would have to be defined and used.
         for (int i = 0; i < 2; i++) {
             printf("%d\n", A2[i]);
         }
+
+        return 0;
     }
 
 In all of the examples above, the source and destination arrays must have
@@ -2132,6 +2154,8 @@ arrays as opposed to their addresses:
         else {
             printf("A1 != A2\n");
         }
+
+        return 0;
     }
 
 You can assign to all the elements of an array in each language in different
@@ -2236,6 +2260,8 @@ are some simple records:
         struct R V;
         V.A = 0;
         printf("V.A = %d\n", V.A);
+
+        return 0;
     }
 
 Ada allows specification of default values for fields just like C. The values
@@ -2348,6 +2374,8 @@ example:
 
         print_r(&V1, "V1");
         print_r(&V2, "V2");
+
+        return 0;
     }
 
 There are many commonalities between the Ada and C semantics above. In Ada and
@@ -2418,6 +2446,8 @@ Here's now a similar example, but using heap allocation instead:
 
         print_r(V1, "V1");
         print_r(V2, "V2");
+
+        return 0;
     }
 
 In this example, an object of type :ada:`R` is allocated on the heap. The same
@@ -2504,6 +2534,8 @@ objects that have gone out of scope. For example:
     {
         int Var;
         int * Ptr = &Var;
+
+        return 0;
     }
 
 To deallocate objects from the heap in Ada, it is necessary to use a
@@ -2538,6 +2570,8 @@ the access type as follows:
     {
         int * my_pointer = malloc (sizeof(int));
         free (my_pointer);
+
+        return 0;
     }
 
 We'll discuss generics later :ref:`in this section <Genericity>`.
@@ -2665,6 +2699,8 @@ Here's a first example:
 
         printf("v1: %d\n", v1);
         printf("v2: %d\n", v2);
+
+        return 0;
     }
 
 The first two declarations for :ada:`Proc` and :ada:`Func` are specifications

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/04_Embedded.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/04_Embedded.rst
@@ -538,6 +538,8 @@ Let's look at this very rudimentary example:
         printf("... * 0.5\n");
         fixed_value = mult(fixed_value, TO_FIXED(0.5));
         display_fixed(fixed_value);
+
+        return 0;
     }
 
 Here, we declare the fixed-point type :c:`fixed` based on :c:`int` and two
@@ -602,6 +604,8 @@ Let's look at a simple example of a volatile variable in C:
             val += i * 2.0;
         }
         printf ("val: %5.3f\n", val);
+
+        return 0;
     }
 
 In this example, :c:`val` has the modifier :c:`volatile`, which indicates that

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/06_Translation.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/06_Translation.rst
@@ -411,6 +411,8 @@ call could be translated:
     int main(int argc, const char * argv[])
     {
         registerInterface_Initialize(15);
+
+        return 0;
     }
 
 [Ada]
@@ -478,6 +480,8 @@ Dynamically allocated arrays can be directly allocated on the stack:
 
     int main() {
         int *a = malloc(sizeof(int) * 10);
+
+        return 0;
     }
 
 [Ada]
@@ -511,6 +515,8 @@ discriminant:
         S v;
 
         v.a = malloc(sizeof(int) * 10);
+
+        return 0;
     }
 
 [Ada]
@@ -565,6 +571,8 @@ through an :ada:`Address` clause associated to a variable, for example:
     int main(int argc, const char * argv[])
     {
         int * r = (int *)0xFFFF00A0;
+
+        return 0;
     }
 
 [Ada]
@@ -613,6 +621,8 @@ boolean flags. In C, this would be done through masks, e.g.:
         int value = 0;
 
         value |= FLAG_2 | FLAG_4;
+
+        return 0;
     }
 
 In Ada, the above can be represented through a Boolean array of enumerate
@@ -651,6 +661,8 @@ representation is needed or more complex data are used:
         int value = 0;
 
         value = (2 << 1) | 1;
+
+        return 0;
     }
 
 [Ada]
@@ -831,6 +843,8 @@ In C, we would rely on bit-shifting and masking to set that specific bit:
         v = v | (1 << 2);
 
         printf("v = %d\n", v);
+
+        return 0;
     }
 
 .. admonition:: Important
@@ -1060,6 +1074,8 @@ bit-shifting and masking to set that specific bit:
         {
             printf("a[%d] = %d\n", i, a[i]);
         }
+
+        return 0;
     }
 
 Since we can use this pattern for any arbitrary data type, this allows us to
@@ -1181,6 +1197,8 @@ shifting and masking to access the bits of that byte. Here, we use the
         rec r = {5, "abc"};
 
         transmit(&r, sizeof(r) * 8);
+
+        return 0;
     }
 
 Similarly, we can write a subprogram that converts a bit-field |mdash| which
@@ -1377,6 +1395,8 @@ individual bytes. For example:
         printf("r2 = ");
         display_r (&r2);
         printf("\n");
+
+        return 0;
     }
 
 Here, :c:`to_r` casts both pointer parameters to pointers to :c:`char` to get

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/06_Translation.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/06_Translation.rst
@@ -794,6 +794,7 @@ Let's look at a simple example:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Bitfield_Ada
+    :class: ada-run
 
     with Ada.Text_IO; use Ada.Text_IO;
 
@@ -913,6 +914,7 @@ In C, we would rely on bit-shifting and masking to set that specific bit:
     [Ada]
 
     .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Overlay_Default_Init_Overwrite
+        :class: ada-run
 
         package P is
 
@@ -969,6 +971,7 @@ In C, we would rely on bit-shifting and masking to set that specific bit:
     [Ada]
 
     .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Overlay_Default_Init_Import
+        :class: ada-run
 
         package P is
 
@@ -1026,6 +1029,7 @@ records. For example:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Bitfield_Int_Array_Ada
+    :class: ada-run
 
     with Ada.Text_IO; use Ada.Text_IO;
 
@@ -1085,6 +1089,7 @@ complex data structures as a bitstream. For example:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Bitfield_Serialization_ada
+    :class: ada-run
 
     package Serializer is
 
@@ -1217,6 +1222,7 @@ procedure:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Bitfield_Deserialization_Ada
+    :class: ada-run
 
     package Serializer is
 
@@ -1445,6 +1451,7 @@ This is the corresponding implementation using overlays:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Simple_Overlay
+    :class: ada-run
 
     with Ada.Text_IO; use Ada.Text_IO;
 
@@ -1507,6 +1514,7 @@ This is how we can rewrite the implementation above using overlays:
 [Ada]
 
 .. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.Translation.Fixed_Int_Overlay
+    :class: ada-run
 
     with Ada.Text_IO; use Ada.Text_IO;
 

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/07_Reusability.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/07_Reusability.rst
@@ -71,6 +71,8 @@ of the type they're being called upon. For example, a swap macro may look like:
         SWAP (int, a, b);
 
         printf("a = %d, b = %d\n", a, b);
+
+        return 0;
     }
 
 Ada offers a way to declare this kind of functions as a generic, that is, a
@@ -602,6 +604,8 @@ is only used for debugging:
     #ifdef DEBUG
         printf("func(%d) => %d\n", a, b);
     #endif
+
+        return 0;
     }
 
 Here, the block indicated by the :c:`DEBUG` flag is only included in the build
@@ -755,6 +759,8 @@ we define the corresponding value of :c:`MOD_VALUE`.
 
         a = 10;
         b = func(a);
+
+        return 0;
     }
 
 If not defined outside, the code above will compile version #1 of the
@@ -869,6 +875,8 @@ with a pointer to an array:
     int main(int argc, const char * argv[])
     {
         S v = init_s (9);
+
+        return 0;
     }
 
 Here, we need to explicitly allocate the :c:`a` array of the :c:`S` struct
@@ -1051,6 +1059,8 @@ We can implement this example in C by using unions:
 
         display (f);
         display (i);
+
+        return 0;
     }
 
 Similar to the Ada code, we declare :ada:`f` containing a floating-point value,
@@ -1265,6 +1275,8 @@ example:
 
         f = calculate (0.5, 1.0, &success);
         display (f, success);
+
+        return 0;
     }
 
 In this code, we're using the output parameter :ada:`success` of the
@@ -1287,6 +1299,8 @@ another computation. For example:
         f = f * 0.25;   // Using f in another computation even though
                         // calculate() returned a dummy value due to error!
                         // We should have evaluated "success", but we didn't.
+
+        return 0;
     }
 
 We cannot prevent access to the returned value or, at least, force the caller
@@ -2181,6 +2195,8 @@ This is an example on how to declare and use pointers to functions in C:
         {
             printf("ERROR: no version of show_msg() selected!\n");
         }
+
+        return 0;
     }
 
 The example above contains two versions of the :c:`show_msg()` function:
@@ -2325,6 +2341,8 @@ calls a callback function (:c:`process_one`) to process a list of values:
         {
             printf("Value [%d] = %d\n", i, values[i]);
         }
+
+        return 0;
     }
 
 As mentioned previously, :c:`process_values()` doesn't have any knowledge about

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/08_Performance.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/08_Performance.rst
@@ -519,6 +519,8 @@ Let's look at this example:
 
         update (&D1, 3);
         display (&D1);
+
+        return 0;
     }
 
 In this C code example, we're using pointers to pass :c:`D1` as a reference to
@@ -641,6 +643,8 @@ data structure. Let's look at this example in C:
         D1 = get_init_data();
 
         init_data(&D1);
+
+        return 0;
     }
 
 This code example contains two subprograms that initialize the :c:`Data`

--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/02_program_consistency.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/02_program_consistency.rst
@@ -150,25 +150,28 @@ unit available directly:
 
 Here, both units :ada:`Ada.Text_IO` and :ada:`Helper` define a procedure
 :ada:`Put_Line` taking a :ada:`String` as argument, so the compiler cannot
-disambiguate the direct call to :ada:`Put_Line` and issues an error. Here is
-output from AdaCore's GNAT Ada compiler:
+disambiguate the direct call to :ada:`Put_Line` and issues an error.
 
-::
+.. only:: builder_html
 
-     1.     with Ada.Text_IO; use Ada.Text_IO;
-     2.     with Helper; use Helper;
-     3.
-     4.     procedure Hello_World is
-     5.     begin
-     6.        Ada.Text_IO.Put_Line ("hello, world!");
-     7.        Helper.Put_Line ("hello, world!");
-     8.        Put_Line ("hello, world!");  --  ERROR
+    Here is output from AdaCore's GNAT Ada compiler:
+
+    ::
+
+         1.     with Ada.Text_IO; use Ada.Text_IO;
+         2.     with Helper; use Helper;
+         3.
+         4.     procedure Hello_World is
+         5.     begin
+         6.        Ada.Text_IO.Put_Line ("hello, world!");
+         7.        Helper.Put_Line ("hello, world!");
+         8.        Put_Line ("hello, world!");  --  ERROR
                |
-        >>> ambiguous expression (cannot resolve "Put_Line")
-        >>> possible interpretation at helper.ads:2
-        >>> possible interpretation at a-textio.ads:508
+            >>> ambiguous expression (cannot resolve "Put_Line")
+            >>> possible interpretation at helper.ads:2
+            >>> possible interpretation at a-textio.ads:508
 
-     9.     end Hello_World;
+         9.     end Hello_World;
 
 Note that it helpfully points to
 candidate declarations, so that the user can decide which qualified name to use
@@ -336,26 +339,27 @@ declarations from what is called the "visible part" of the spec
        Body_Put_Line ("hello, world!");  --  ERROR
     end Hello_World;
 
-Here's the output from AdaCore's GNAT compiler:
+.. only:: builder_html
 
-::
+    Here's the output from AdaCore's GNAT compiler:
 
-     1.     with Helper; use Helper;
-     2.
-     3.     procedure Hello_World is
-     4.     begin
-     5.        Public_Put_Line ("hello, world!");
-     6.        Private_Put_Line ("hello, world!");  --  ERROR
-               |
-        >>> "Private_Put_Line" is not visible
-        >>> non-visible (private) declaration at helper.ads:4
+    ::
 
-     7.        Body_Put_Line ("hello, world!");  --  ERROR
-               |
-        >>> "Body_Put_Line" is undefined
+         1.     with Helper; use Helper;
+         2.
+         3.     procedure Hello_World is
+         4.     begin
+         5.        Public_Put_Line ("hello, world!");
+         6.        Private_Put_Line ("hello, world!");  --  ERROR
+                   |
+            >>> "Private_Put_Line" is not visible
+            >>> non-visible (private) declaration at helper.ads:4
 
-     8.     end Hello_World;
+         7.        Body_Put_Line ("hello, world!");  --  ERROR
+                   |
+            >>> "Body_Put_Line" is undefined
 
+         8.     end Hello_World;
 
 Note the different errors on the calls to the private and body versions of
 :ada:`Put_Line`. In the first case the compiler can locate the candidate procedure

--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
@@ -515,28 +515,30 @@ Here's an attempt to simulate the above C code in SPARK (and Ada):
 
     end Bad_Arith;
 
-Here is the output from AdaCore's GNAT compiler:
+.. only:: builder_html
 
-::
+    Here is the output from AdaCore's GNAT compiler:
 
-     1.     package Bad_Arith is
-     2.
-     3.        B1 : constant Boolean := True;
-     4.        B2 : constant Boolean := False;
-     5.        B3 : constant Boolean := B1 + B2;
+    ::
+
+         1.     package Bad_Arith is
+         2.
+         3.        B1 : constant Boolean := True;
+         4.        B2 : constant Boolean := False;
+         5.        B3 : constant Boolean := B1 + B2;
                                            |
-        >>> there is no applicable operator "+" for type "Standard.Boolean"
+            >>> there is no applicable operator "+" for type "Standard.Boolean"
 
-     6.
-     7.        type Fruit is (Apple, Orange);
-     8.        F1 : constant Fruit := Apple;
-     9.        F2 : constant Fruit := Orange;
-    10.        F3 : constant Fruit := F1 + F2;
+         6.
+         7.        type Fruit is (Apple, Orange);
+         8.        F1 : constant Fruit := Apple;
+         9.        F2 : constant Fruit := Orange;
+        10.        F3 : constant Fruit := F1 + F2;
                                          |
-        >>> there is no applicable operator "+" for type "Fruit" defined at line 7
+            >>> there is no applicable operator "+" for type "Fruit" defined at line 7
 
-    11.
-    12.     end Bad_Arith;
+        11.
+        12.     end Bad_Arith;
 
 It is possible, however, to get the predecessor of a Boolean or enumerated
 value with :ada:`Value'Pred` and its successor with :ada:`Value'Succ`, as well as

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -164,7 +164,7 @@ $(BOOKS):
 	@export SPHINX_TITLE="$(SPHINX_TITLE)"; \
 	  export SPHINX_AUTHOR="$(SPHINX_AUTHOR)"; \
 	  export SRC_TEST_DIR="$(SRC_TEST_DIR)"; \
-	$(SPHINXBUILD) -M latexpdf $@ \
+	GEN_LEARN_SITE=yes $(SPHINXBUILD) -M latexpdf $@ \
 	   "$(BUILDDIR)" $(SPHINXOPTS) $(O) -v -c "$(SPHINXCONF)"
 	@mv $(BUILDDIR)/latex/learnadacorecom.pdf $(BUILDDIR)/pdf_books/$(SPHINX_DIR)/$(SPHINX_PDF)
 

--- a/frontend/sphinx/conf.py
+++ b/frontend/sphinx/conf.py
@@ -33,7 +33,7 @@ title = u'Learn Ada (Complete)' if 'SPHINX_TITLE' not in os.environ else \
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'2021-01'
+release = u'2021-02'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -102,8 +102,7 @@ class WidgetCodeDirective(Directive):
                                             f.content,
                                             format='latex')
             literal['language'] = self.arguments[0].split(' ')[0]
-            literal['linenos'] = 'linenos' in self.options or \
-                'lineno-start' in self.options
+            literal['linenos'] = True
             literal['source'] = f.basename
 
             caption = nodes.caption('', f.basename)

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -347,6 +347,9 @@ def analyze_file(rst_file):
                 diags.append(Diag(f, int(l), int(c), t))
         return diags
 
+    def remove_string(some_text, rem):
+        return re.sub(".*" + rem + ".*\n?","", some_text)
+
     projects = dict()
 
     for (i, b) in code_blocks:
@@ -482,9 +485,6 @@ def analyze_file(rst_file):
                 project_block_dir = make_project_block_dir()
 
                 if block.language == "ada":
-
-                    def remove_string(some_text, rem):
-                        return re.sub(".*" + rem + ".*\n?","", some_text)
 
                     try:
                         out = run("gprbuild", "-gnata", "-gnatyg0-s", "-f",
@@ -638,6 +638,7 @@ def analyze_file(rst_file):
                             has_error = True
                         out = str(e.output.decode("utf-8"))
 
+                    out = remove_string(out, "Summary logged in")
                     with open(project_block_dir + "/prove.log", u"w") as logfile:
                         logfile.write(out)
                 else:


### PR DESCRIPTION
- Printing line numbers for all source-code examples of PDF books.
- Removing to-do items from PDF books.
- Updating release date.
- Fixing source-code examples ("return 0" was missing).
- Including runtime output for some examples without run button (using "ada-run" class).
- Removing some paragraphs containing "hard-coded" compiler output.
- Removing "summary logged in" line from prover output.
