### PR TITLE
Fixing unspecified main failures.

### DIFF
--- a/backend/app/widget/project.py
+++ b/backend/app/widget/project.py
@@ -143,7 +143,7 @@ class Project:
         self.gpr.insert_languages(languages)
 
         # Figure out which files are mains
-        if 'main' in data.keys():
+        if 'main' in data.keys() and data['main']:
             self.main = data['main']
         else:
             mains = find_mains(self.file_list)


### PR DESCRIPTION
Empty mains were causing "no main found" errors in the backend. 