### PR TITLE
Add note that lab/stack proof errors are expected

### DIFF
--- a/content/labs/bug-free-coding/chapters/stack.rst
+++ b/content/labs/bug-free-coding/chapters/stack.rst
@@ -123,7 +123,9 @@ Sample Output
 .. only:: builder_html
 
     Note that, in order to prove the code below, you need to click on the
-    *Prove* button.
+    *Prove* button. Note also that errors are expected initially |mdash| it is
+    up to you to use the output from the prover to correct these and produce a
+    working, fully proved stack!
 
 .. code:: ada lab=MLH_Stack prove_button
 


### PR DESCRIPTION
The purpose of the stack lab is to use output from the prover to
complete the stack. Add a note to that effect to remind the user,
so that they are not surprised to see errors when they click
Prove.