### PR TITLE
Update cloudchecker-staging URL

### DIFF
--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -59,8 +59,8 @@ from code_block_info import CodeBlockInfo
 
 # specifies the server address to set on the widgets
 WIDGETS_SERVER_URL = os.environ.get(
-    "CODE_SERVER_URL",
-    "https://cloudchecker-staging.r53.adacore.com")
+    "CODE_SERVER_URL", "https://cloudchecker-staging.learn.r53.adacore.com"
+)
 
 
 class WidgetCodeDirective(Directive):

--- a/frontend/tests/ts/widget.spec.ts
+++ b/frontend/tests/ts/widget.spec.ts
@@ -58,7 +58,7 @@ describe('Widget', () => {
   let inTest: Array<HTMLElement>;
   let root: HTMLElement;
 
-  const baseURL = 'https://cloudchecker-staging.r53.adacore.com';
+  const baseURL = 'https://cloudchecker-staging.learn.r53.adacore.com';
   describe('Single Widget', () => {
     before(() => {
       fillDOM('single.html');


### PR DESCRIPTION
The new URL provides an updated cloudchecker service with GNAT Community
2021 installed.

TN: U604-038