### PR TITLE
Refresh content of SPARK-for-MISRA-C-Developer guide

### DIFF
--- a/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
+++ b/content/courses/SPARK_for_the_MISRA_C_Developer/chapters/04_strong_typing.rst
@@ -100,9 +100,9 @@ The added syntax helps first in making clear what is happening and, second,
 in ensuring that a potentially dangerous feature (assigning to a value at a
 specific machine address) is not used inadvertently.
 
-The above example is legal Ada but not SPARK, since SPARK does not support
-pointers (they significantly complicate formal analysis). SPARK does allow
-addresses, however.
+The above example is legal in SPARK, but the SPARK analysis tool issues
+warnings as it cannot control how the program or its environment may update the
+memory cell at address 42.
 
 Pointers Are Not References
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,13 +117,14 @@ persists after the first object has ceased to exist"`. Unfortunately, enforcing
 this rule is difficult, as it is undecidable.
 
 In SPARK, parameters can be passed by reference, but no pointer to the
-parameter can be stored, which completely solves this issue. In fact, the
-decision to pass a parameter by copy or by reference rests in many cases with
-the compiler, but such compiler dependency has no effect on the functional
-behavior of a SPARK program. In the example below, the compiler may decide to pass
-parameter :ada:`P` of procedure :ada:`Rotate_X` either by copy or by reference, but
-regardless of the choice the postcondition of :ada:`Rotate_X` will hold:
-the final value of :ada:`P` will be modified by rotation around the :ada:`X` axis.
+parameter can be stored past the return point of the function, which completely
+solves this issue. In fact, the decision to pass a parameter by copy or by
+reference rests in many cases with the compiler, but such compiler dependency
+has no effect on the functional behavior of a SPARK program. In the example
+below, the compiler may decide to pass parameter :ada:`P` of procedure
+:ada:`Rotate_X` either by copy or by reference, but regardless of the choice
+the postcondition of :ada:`Rotate_X` will hold: the final value of :ada:`P`
+will be modified by rotation around the :ada:`X` axis.
 
 .. code:: ada prove_report_all_button compile_button project=Courses.SPARK_For_The_MISRA_C_Dev.Strong_Typing.Geometry
 


### PR DESCRIPTION
Correct references to illegality of pointers in SPARK. Rather, SPARK
analysis tool accepts pointers and detects problematic constructs now.