### PR TITLE
Minor fixes for the course on what's new in Ada 2022

### DIFF
--- a/content/courses/whats-new-in-ada-2022/chapters/array_aggregates.rst
+++ b/content/courses/whats-new-in-ada-2022/chapters/array_aggregates.rst
@@ -54,8 +54,8 @@ expression. It declares an index parameter that you can use in the
 computation of a component.
 
 Iterated component associations can nest and can be nested in another
-association (iterated or not). But you can't mix iterated and not iterated
-association in one list. Here we use this to define a square matrix:
+association (iterated or not). You can even mix iterated and not iterated
+associations in one list. Here we use this to define a square matrix:
 
 .. code-block:: ada
 

--- a/content/courses/whats-new-in-ada-2022/chapters/assignment_target.rst
+++ b/content/courses/whats-new-in-ada-2022/chapters/assignment_target.rst
@@ -118,9 +118,9 @@ In Ada 2022, you can use a similar renaming:
       A := A ** 2 - 3.0 * A;
    end;
 
-Here we use a new short form of the rename declaration, but this still
-looks too heavy, and even worse, it can't be used for discriminant
-dependent-components.
+Here we use a new short form of the rename declaration, but this still looks
+too heavy, and even worse, it can't be used for discriminant-dependent
+components.
 
 References
 ----------

--- a/content/courses/whats-new-in-ada-2022/chapters/image_attribute.rst
+++ b/content/courses/whats-new-in-ada-2022/chapters/image_attribute.rst
@@ -33,7 +33,7 @@ statements are equivalent:
 ------------------------------------
 
 In Ada 2022, you can apply the :ada:`'Image` attribute to any type,
-including records, array, access types, and private types. Let's see how
+including records, arrays, access types, and private types. Let's see how
 this works. We'll define array, record, and access types and corresponding
 objects and then convert these objects to strings and print them:
 

--- a/content/courses/whats-new-in-ada-2022/chapters/importing_variadic_functions.rst
+++ b/content/courses/whats-new-in-ada-2022/chapters/importing_variadic_functions.rst
@@ -1,3 +1,5 @@
+:next_state: False
+
 .. include:: ../../global.txt
 
 Interfacing C variadic functions

--- a/content/courses/whats-new-in-ada-2022/chapters/introduction.rst
+++ b/content/courses/whats-new-in-ada-2022/chapters/introduction.rst
@@ -12,8 +12,8 @@ line switch or pragma. Compilers starting with `GNAT Community Edition
 2021`_ or `GCC 11`_ use :ada:`pragma Ada_2022;` or the ``-gnat2022``
 switch.  Older compilers use :ada:`pragma Ada_2020;` or
 ``-gnat2020``. To use the square brackets syntax or :ada:`'Reduce`
-expressions, you need :ada:`pragma Extensions_Allowed (On);` the or
-``-gnatX`` swith.
+expressions, you need :ada:`pragma Extensions_Allowed (On);` or the
+``-gnatX`` switch.
 
 References
 ----------


### PR DESCRIPTION
* content/courses/whats-new-in-ada-2022/chapters/array_aggregates.rst
Fix text as iterated component associations are allowed to mix with other
associations.
* content/courses/whats-new-in-ada-2022/chapters/assignment_target.rst
Fix hyphen.
* content/courses/whats-new-in-ada-2022/chapters/image_attribute.rst
Fix plural.
* courses/whats-new-in-ada-2022/chapters/importing_variadic_functions.rst
Remove Next button on last chapter.
* content/courses/whats-new-in-ada-2022/chapters/introduction.rst
Fix typo.