### PR TITLE
Drop `void` in C++ profile

### DIFF
--- a/content/courses/Ada_For_The_CPP_Java_Developer/chapters/05_Type_System.rst
+++ b/content/courses/Ada_For_The_CPP_Java_Developer/chapters/05_Type_System.rst
@@ -24,7 +24,7 @@ One of the main characteristics of Ada is its strong typing (i.e., relative abse
 
 .. code-block:: cpp
 
-   void weakTyping (void) {
+   void weakTyping () {
       int   alpha = 1;
       int   beta = 10;
       float result;


### PR DESCRIPTION
According to C++ standards parameterless profile looks like
`()` not like `(void)`.