### PR TITLE
Fix some code blocks

### DIFF
--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
@@ -1768,7 +1768,7 @@ consider this C example:
 
 [C]
 
-.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_0
+.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_C
 
     !main.c
     #include <stdio.h>
@@ -1788,7 +1788,7 @@ The corresponding code in Ada raises an exception:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_1
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_Ada
     :class: ada-run-expect-failure
 
     with Ada.Text_IO; use Ada.Text_IO;
@@ -1809,7 +1809,7 @@ a 32-bit modular type:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_2
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_Ada
 
     with Ada.Text_IO; use Ada.Text_IO;
 

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/02_Perspective.rst
@@ -1768,7 +1768,7 @@ consider this C example:
 
 [C]
 
-.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound
+.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_0
 
     !main.c
     #include <stdio.h>
@@ -1788,7 +1788,7 @@ The corresponding code in Ada raises an exception:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_1
     :class: ada-run-expect-failure
 
     with Ada.Text_IO; use Ada.Text_IO;
@@ -1809,7 +1809,7 @@ a 32-bit modular type:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Perspective.Overflow_Wraparound_2
 
     with Ada.Text_IO; use Ada.Text_IO;
 

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
@@ -633,7 +633,7 @@ benefits, and it can be reached with comparatively low cost.
 
 For example, the following illustrates an initialization failure:
 
-.. code:: ada prove_flow_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_0
+.. code:: ada prove_flow_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_0 main=main.adb
    :class: ada-expect-prove-error
 
    with Increment;

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
@@ -746,7 +746,7 @@ though they are *about* the bodies. Placement on the declarations allows
 the obligations and guarantees to be visible to all parties. For
 example:
 
-.. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_1
+.. code:: ada no_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_2
 
     function Mid (X, Y : Integer) return Integer with
        Pre  => X + Y /= 0,
@@ -976,7 +976,7 @@ positive value, the attempt to increment it would overflow, raising
 deal with.) We added a precondition to allow only the integer values up to,
 but not including, the largest positive value:
 
-.. code:: ada prove_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_2
+.. code:: ada prove_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_5
 
    procedure Increment (Value : in out Integer) with
      Pre  => Value < Integer'Last,

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/05_SPARK.rst
@@ -579,7 +579,7 @@ As it turns out, our procedure :ada:`Main` is already SPARK compliant so
 we can start verifying it.
 
 .. code:: ada prove_button run_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Assert
-   :class: ada-run-expect-failure
+   :class: ada-run-expect-failure, ada-expect-prove-error
 
    with Ada.Text_IO; use Ada.Text_IO;
 
@@ -634,6 +634,7 @@ benefits, and it can be reached with comparatively low cost.
 For example, the following illustrates an initialization failure:
 
 .. code:: ada prove_flow_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_0
+   :class: ada-expect-prove-error
 
    with Increment;
    with Ada.Text_IO; use Ada.Text_IO;
@@ -658,7 +659,7 @@ to the argument passed to :ada:`Increment`.
 Consider this next routine, which contains a serious coding error. Flow
 analysis will find it for us.
 
-.. code:: ada prove_flow_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_0
+.. code:: ada prove_flow_button project=Courses.Ada_For_Embedded_C_Dev.SPARK.Contracts_1
    :class: ada-expect-prove-error
 
    with Ada.Numerics.Elementary_Functions;  use Ada.Numerics.Elementary_Functions;

--- a/content/courses/Ada_For_The_Embedded_C_Developer/chapters/08_Performance.rst
+++ b/content/courses/Ada_For_The_Embedded_C_Developer/chapters/08_Performance.rst
@@ -218,7 +218,7 @@ consider the following example in C:
 
 [C]
 
-.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero
+.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero_C
     :class: c-run-expect-failure
 
     !main.c
@@ -244,7 +244,7 @@ manually introduce a check for zero before this operation. For example:
 
 [C]
 
-.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero_Check
+.. code:: c manual_chop run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero_Check_C
 
     !main.c
     #include <stdio.h>
@@ -272,7 +272,7 @@ This is the corresponding code in Ada:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero_Ada
     :class: ada-run-expect-failure
 
     with Ada.Text_IO; use Ada.Text_IO;
@@ -296,7 +296,7 @@ the same message as we did in the second version of the C code:
 
 [Ada]
 
-.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero
+.. code:: ada run_button project=Courses.Ada_For_Embedded_C_Dev.Performance.Division_By_Zero_Check_Ada
 
     with Ada.Text_IO; use Ada.Text_IO;
 

--- a/content/courses/intro-to-spark/chapters/01_Overview.rst
+++ b/content/courses/intro-to-spark/chapters/01_Overview.rst
@@ -165,7 +165,7 @@ the order in which the two calls to F are evaluated.  It's therefore not
 legal SPARK.
 
 .. code:: ada prove_flow_button run_button project=Courses.Intro_To_Spark.Overview.Illegal_Ada_Code
-    :class: ada-ada-expect-prove-error, expect-compile-error
+    :class: ada-expect-prove-error, ada-expect-compile-error
 
     procedure Show_Illegal_Ada_Code is
 

--- a/content/courses/intro-to-spark/chapters/01_Overview.rst
+++ b/content/courses/intro-to-spark/chapters/01_Overview.rst
@@ -165,7 +165,7 @@ the order in which the two calls to F are evaluated.  It's therefore not
 legal SPARK.
 
 .. code:: ada prove_flow_button run_button project=Courses.Intro_To_Spark.Overview.Illegal_Ada_Code
-    :class: ada-expect-compile-error
+    :class: ada-ada-expect-prove-error, expect-compile-error
 
     procedure Show_Illegal_Ada_Code is
 
@@ -510,7 +510,7 @@ applies a circular permutation to the value of its three parameters.
 :ada:`Swap` then uses :ada:`Permute` to swap the value of :ada:`X` and :ada:`Y`.
 
 .. code:: ada run_button prove_flow_button project=Courses.Intro_To_Spark.Overview.Example_03
-    :class: ada-expect-compile-error
+    :class: ada-expect-compile-error, ada-expect-prove-error
 
     package P
       with SPARK_Mode => On

--- a/content/courses/intro-to-spark/chapters/04_State_Abstraction.rst
+++ b/content/courses/intro-to-spark/chapters/04_State_Abstraction.rst
@@ -1029,7 +1029,7 @@ Example #6
 Let's consider yet another version of our abstract stack unit.
 
 .. code:: ada compile_button prove_flow_button project=Courses.Intro_To_Spark.State_Abstraction.Example_06
-    :class: ada-expect-compile-error
+    :class: ada-expect-compile-error, ada-expect-prove-error
 
     package Stack with
       Abstract_State => The_Stack

--- a/content/courses/intro-to-spark/chapters/05_Proof_Of_Functional_Correctness.rst
+++ b/content/courses/intro-to-spark/chapters/05_Proof_Of_Functional_Correctness.rst
@@ -282,7 +282,7 @@ However, :ada:`X_Init` can't be used in normal code, for example to restore
 the initial value of :ada:`X`.
 
 .. code:: ada prove_button run_button project=Courses.Intro_To_Spark.Proof_of_Functional_Correctness.Ghost_2
-    :class: ada-expect-compile-error
+    :class: ada-expect-prove-error, ada-expect-compile-error
 
     package Show_Ghost is
 
@@ -450,7 +450,7 @@ specify that :ada:`B` can't be accessed twice in a row without accessing :ada:`A
 in between.
 
 .. code:: ada prove_button run_button project=Courses.Intro_To_Spark.Proof_of_Functional_Correctness.Global_Ghost_Vars
-    :class: ada-run-expect-failure
+    :class: ada-expect-prove-error, ada-run-expect-failure
 
     package Call_Sequence is
 
@@ -1162,7 +1162,7 @@ Instead of using a ghost function, :ada:`Get_Model`, to retrieve the contents
 of the ring buffer, we're now using a global ghost variable, :ada:`Model`.
 
 .. code:: ada compile_button prove_button project=Courses.Intro_To_Spark.Proof_of_Functional_Correctness.Example_02
-    :class: ada-expect-compile-error
+    :class: ada-expect-compile-error, ada-expect-prove-error
 
     package Ring_Buffer is
 
@@ -1283,7 +1283,7 @@ We're now modifying :ada:`Push_Last` to share the computation of the new
 length between the operational and ghost code.
 
 .. code:: ada compile_button prove_button project=Courses.Intro_To_Spark.Proof_of_Functional_Correctness.Example_04
-    :class: ada-expect-compile-error
+    :class: ada-expect-compile-error, ada-expect-prove-error
 
     package Ring_Buffer is
 
@@ -1517,7 +1517,7 @@ the same bounds. We want to prove that :ada:`Max_Array` returns an array of
 the maximum values of both its arguments at each index.
 
 .. code:: ada prove_button run_button project=Courses.Intro_To_Spark.Proof_of_Functional_Correctness.Example_08
-    :class: ada-run-expect-failure
+    :class: ada-expect-prove-error, ada-run-expect-failure
 
     package Array_Util is
 


### PR DESCRIPTION
Some code blocks were pulling in files that they shouldn't have been because they shared a project name with a code block that they shouldn't have.

Some tests were also failing due to missing failure expectations