### PR TITLE
Prevent user from spamming execute buttons

### DIFF
--- a/frontend/src/ts/widget.ts
+++ b/frontend/src/ts/widget.ts
@@ -117,7 +117,9 @@ class Widget {
     for (const btn of buttons) {
       const mode = btn.dataset.mode as string;
       btn.addEventListener('click', async () => {
+        buttons.forEach((btn) => btn.setAttribute('disabled', ''));
         await this.buttonCB(mode);
+        buttons.forEach((btn) => btn.removeAttribute('disabled'));
       });
     }
 


### PR DESCRIPTION
Currently when a user presses a button, to execute some task, multiple times in quick succession, this can cause messages from multiple executions to appear in the output area.

~~This change should prevent this from happening, with only the output from the final press being displayed~~
This change makes it so that when any execute button is pressed, all execute buttons for that code block are disabled until the task is complete.