### PR TITLE
Infrastructure: adding support for zipfile with source-code examples

### DIFF
--- a/.github/workflows/sphinx-books-tests.js.yml
+++ b/.github/workflows/sphinx-books-tests.js.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Run Webpack production
       run: make cleanall webpack-production
     - name: Run SPHINX content tests
-      run: make -k test_content
+      run: make -k test_all_content
     - name: Build PDF books including build/runtime output
       run: make pdf_books
     - name: Archive PDF books in artifact

--- a/content/index.rst
+++ b/content/index.rst
@@ -121,6 +121,10 @@
                             <a class="ebook-download-button" href="/epub_books/learning-ada.epub">
                                 EPUB
                             </a>
+
+                            <a class="ebook-download-button" href="/zip/learning-ada_code.zip">
+                                ZIP (source code)
+                            </a>
                         </div>
 
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -94,18 +94,23 @@ test_training_fundamentals:
 	@echo ""
 
 test_content: test_ada_intro test_spark_intro test_intro_to_embedded_sys_prog \
-	test_advanced_ada test_advanced_spark \
 	test_whats_new_in_ada_2022 \
 	test_spark_for_the_misra_c_developer \
 	test_ada_for_the_cpp_java_developer \
 	test_ada_for_the_embedded_c_developer \
-	test_training_fundamentals \
 	test_gnat_toolchain_intro
 	@cd $(SRC_TEST_DIR) \
 		&& zip -9 -r $(COMPLETE_SITE_BOOK)_code.zip . \
 			-x "*.log" -x "*/latest*"
 	@mkdir -p $(BUILDDIR)/zip
 	@mv $(SRC_TEST_DIR)/$(COMPLETE_SITE_BOOK)_code.zip $(BUILDDIR)/zip
+
+test_hidden_content: test_advanced_ada test_advanced_spark \
+	test_training_fundamentals
+	@echo ""
+
+test_all_content: test_content test_hidden_content
+	@echo ""
 
 test_lambda_ada_intro:
 	@echo "===== INTRO TO ADA ====="

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -22,6 +22,9 @@ HIDDEN_BOOKS 	?= $(CONTENT_DIR)/hidden.txt
 WEBSOCKET_URL_PROD      = wss://api.learn.r53.adacore.com
 export CODE_SERVER_URL := wss://api-sandbox.learn.r53.adacore.com
 
+COMPLETE_SITE_BOOK = learning-ada
+
+
 help:
 	@echo "make test_content  - run the testsuite"
 	@echo "make test_engine  - generate the engine test html"
@@ -98,6 +101,11 @@ test_content: test_ada_intro test_spark_intro test_intro_to_embedded_sys_prog \
 	test_ada_for_the_embedded_c_developer \
 	test_training_fundamentals \
 	test_gnat_toolchain_intro
+	@cd $(SRC_TEST_DIR) \
+		&& zip -9 -r $(COMPLETE_SITE_BOOK)_code.zip . \
+			-x "*.log" -x "*/latest*"
+	@mkdir -p $(BUILDDIR)/zip
+	@mv $(SRC_TEST_DIR)/$(COMPLETE_SITE_BOOK)_code.zip $(BUILDDIR)/zip
 
 test_lambda_ada_intro:
 	@echo "===== INTRO TO ADA ====="
@@ -229,8 +237,6 @@ site-testing: cleantest
         "$(TEST_BUILDDIR)" $(SPHINXOPTS) $(O) -v -c "$(SPHINXCONF)"
 
 BOOKS = $(wildcard $(CONTENT_DIR)/courses/*/.) $(wildcard $(CONTENT_DIR)/labs/*/.)
-
-COMPLETE_SITE_BOOK = learning-ada
 
 PDF_BOOKS_DIR := $(BUILDDIR)/pdf_books
 

--- a/frontend/sphinx/code_block_info.py
+++ b/frontend/sphinx/code_block_info.py
@@ -5,6 +5,7 @@ from typing import List, Dict
 import glob
 
 import os
+import json
 
 class CodeBlockInfo():
     """Code block info class
@@ -56,4 +57,11 @@ class CodeBlockInfo():
                 log_type = os.path.splitext(os.path.basename(logfile))[0]
                 info[log_type] = content
 
+        block_info_json_file = code_block_dir + "/block_info.json"
+        if os.path.isfile(block_info_json_file):
+            with open(block_info_json_file, u'r') as f:
+                block_info_json = json.load(f)
+                info['_metadata'] = block_info_json
+        else:
+            info['_metadata'] = None
         return info

--- a/frontend/sphinx/code_block_info.py
+++ b/frontend/sphinx/code_block_info.py
@@ -64,4 +64,7 @@ class CodeBlockInfo():
                 info['_metadata'] = block_info_json
         else:
             info['_metadata'] = None
+
+        self.__info = info
+
         return info

--- a/frontend/sphinx/code_block_info.py
+++ b/frontend/sphinx/code_block_info.py
@@ -19,12 +19,14 @@ class CodeBlockInfo():
     def __init__(self,
                  project_name : str,
                  filename : str,
-                 line_number: int):
+                 line_number: int,
+                 text_hash_short: str):
         """Widget constructor
         """
         self.__project_name: str = project_name
         self.__filename: str = filename
         self.__line_number: int = line_number
+        self.__text_hash_short: str = text_hash_short
         self.__src_test_data_dir = ""
         self.__data_available = False
 
@@ -39,7 +41,7 @@ class CodeBlockInfo():
         return (self.__src_test_data_dir + "/" +
                 self.base_project_dir + "/" +
                 self.__get_project_dir() + "/" +
-                str(self.__line_number))
+                self.__text_hash_short)
 
     def get_info(self) -> Dict[str, str]:
         """

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -127,6 +127,12 @@ class WidgetCodeDirective(Directive):
                     'compile' : '\\textbf{Compilation output}',
                     'prove'   : '\\textbf{Prover output}'
                 }
+
+                if info_type in known_info_type:
+                    return known_info_type[info_type]
+                else:
+                    return ''
+
             if node_format == 'html':
                 known_info_type = {
                     'build'   : r"<div class='literal-block-preamble'>Build output</div>",
@@ -135,10 +141,10 @@ class WidgetCodeDirective(Directive):
                     'prove'   : r"<div class='literal-block-preamble'>Prover output</div>"
                 }
 
-            if info_type in known_info_type:
-                return known_info_type[info_type]
-            else:
-                return "Let's " + info_type + " the example:"
+                if info_type in known_info_type:
+                    return known_info_type[info_type]
+                else:
+                    return "Let's " + info_type + " the example:"
 
         block_info : Dict[str, str] = code_block_info.get_info()
 

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -213,7 +213,8 @@ class WidgetCodeDirective(Directive):
                 continue
 
             results[info_type] = str(block_info[info_type])
-            print(str(block_info[info_type]))
+            # print("---- " + info_type + ":")
+            # print(str(block_info[info_type]))
 
         return results
 

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -208,6 +208,10 @@ class WidgetCodeDirective(Directive):
 
         for info_type in sorted(block_info):
 
+            if info_type == "_metadata":
+                # Do not add metadata block
+                continue
+
             if block_info[info_type] == "":
                 # Do not add empty info blocks
                 continue

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -44,6 +44,7 @@ The files are extracted the following way:
 """
 # System libs
 import os
+import hashlib
 from typing import List, Dict, Any
 
 # HTML Template Libs
@@ -241,6 +242,14 @@ class WidgetCodeDirective(Directive):
             if self.options:
                 widget.parseOpts(self.options)
 
+            # Hash of source-code
+            #
+            # str_content: adapting content into format used in
+            #              compile_blocks.py
+            str_content = ('\n'.join(self.content) + "\n").encode("utf-8")
+            text_hash = hashlib.sha512(str_content).hexdigest()
+            text_hash_short = hashlib.md5(str_content).hexdigest()
+
             # chop contents into files
             widget.parseContent(self.content)
 
@@ -259,7 +268,8 @@ class WidgetCodeDirective(Directive):
                 if 'no_button' in self.arguments[0]:
                     code_block_info = CodeBlockInfo(project_name=widget.name,
                                                     filename=self.content.items[0][0],
-                                                    line_number=self.content.items[0][1] - 1)
+                                                    line_number=self.content.items[0][1] - 1,
+                                                    text_hash_short=text_hash_short)
                     widget.parseCodeBlockInfo(self.get_code_block_info(code_block_info))
 
                 # insert widget into the template
@@ -270,7 +280,8 @@ class WidgetCodeDirective(Directive):
             else:
                 code_block_info = CodeBlockInfo(project_name=widget.name,
                                                 filename=self.content.items[0][0],
-                                                line_number=self.content.items[0][1] - 1)
+                                                line_number=self.content.items[0][1] - 1,
+                                                text_hash_short=text_hash_short)
                 if ('builder_latex' in self.state.state_machine.document.settings.env.app.tags.tags
                     and self.state.state_machine.document.settings.env.app.tags.tags['builder_latex']):
                     nodes_latex = self.create_static_node(widget, code_block_info, 'latex')

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -122,6 +122,7 @@ class WidgetCodeDirective(Directive):
 
             if node_format == 'latex':
                 known_info_type = {
+                    '_metadata' : '\\textbf{Code block metadata}',
                     'build'   : '\\textbf{Build output}',
                     'run'     : '\\textbf{Runtime output}',
                     'compile' : '\\textbf{Compilation output}',
@@ -135,6 +136,7 @@ class WidgetCodeDirective(Directive):
 
             if node_format == 'html':
                 known_info_type = {
+                    '_metadata' : r"<div class='literal-block-preamble'>Metadata</div>",
                     'build'   : r"<div class='literal-block-preamble'>Build output</div>",
                     'run'     : r"<div class='literal-block-preamble'>Runtime output</div>",
                     'compile' : r"<div class='literal-block-preamble'>Compilation output</div>",
@@ -150,11 +152,21 @@ class WidgetCodeDirective(Directive):
 
         for info_type in sorted(block_info):
 
-            if block_info[info_type] == "":
+            if (block_info[info_type] is None or
+                block_info[info_type] == ""):
                 # Do not show empty boxes
                 continue
 
             output_info = block_info[info_type]
+            if info_type == "_metadata":
+                output_info = ("Project: " +
+                    block_info[info_type]['project'])
+                output_info += '\n'
+                output_info += ("MD5: " +
+                    block_info[info_type]['text_hash_short'])
+                # output_info += '\n'
+                # output_info += str(block_info[info_type])
+
             preamble_node = nodes.container(
                 '', literal_block=False,
                 classes=[])

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -137,7 +137,7 @@ class WidgetCodeDirective(Directive):
 
             if node_format == 'html':
                 known_info_type = {
-                    '_metadata' : r"<div class='literal-block-preamble'>Metadata</div>",
+                    '_metadata' : r"<div class='literal-block-preamble'>Code block metadata</div>",
                     'build'   : r"<div class='literal-block-preamble'>Build output</div>",
                     'run'     : r"<div class='literal-block-preamble'>Runtime output</div>",
                     'compile' : r"<div class='literal-block-preamble'>Compilation output</div>",

--- a/frontend/sphinx/widget_extension.py
+++ b/frontend/sphinx/widget_extension.py
@@ -154,6 +154,7 @@ class WidgetCodeDirective(Directive):
                 # Do not show empty boxes
                 continue
 
+            output_info = block_info[info_type]
             preamble_node = nodes.container(
                 '', literal_block=False,
                 classes=[])
@@ -169,7 +170,7 @@ class WidgetCodeDirective(Directive):
                 classes=['literal-block-wrapper'])
 
             literal = nodes.literal_block('',
-                                          block_info[info_type],
+                                          output_info,
                                           format=node_format)
             literal['language'] = 'none'
             literal['source'] = info_type

--- a/frontend/tests/code_block.py
+++ b/frontend/tests/code_block.py
@@ -4,8 +4,9 @@ from typing import List, Optional
 from colors import col, Colors
 
 class CodeBlock:
-    def __init__(self, line_start, line_end, text, language, project,
+    def __init__(self, rst_file, line_start, line_end, text, language, project,
                  main_file, compiler_switches, classes, manual_chop, buttons, src_file):
+        self.rst_file: str = rst_file
         self.line_start: int = line_start
         self.line_end: int = line_end
         self.text: str = text

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -576,6 +576,7 @@ def analyze_file(rst_file):
                     main_file = source_files[-1].basename
                 return main_file
 
+            project_filename = None
 
             if compile_block:
 
@@ -780,6 +781,15 @@ def analyze_file(rst_file):
                 analysis_error = True
             elif args.verbose:
                 print(C.col("SUCCESS", C.Colors.GREEN))
+
+            # Clean-up source-code examples after compilation
+            if (block.language == "ada" and
+                project_filename is not None):
+
+                try:
+                    run("gprclean", "-P", project_filename)
+                except S.CalledProcessError as e:
+                    out = str(e.output.decode("utf-8"))
 
             if args.all_diagnostics:
                 print_diags()

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -508,6 +508,7 @@ def analyze_file(rst_file):
             if args.verbose:
                 print(header("Checking code block {}".format(loc)))
 
+            # Syntax check
             for source_file in source_files:
 
                 try:

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -783,8 +783,7 @@ def analyze_file(rst_file):
                 print(C.col("SUCCESS", C.Colors.GREEN))
 
             # Clean-up source-code examples after compilation
-            if (block.language == "ada" and
-                project_filename is not None):
+            if project_filename is not None:
 
                 try:
                     run("gprclean", "-P", project_filename)

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -81,11 +81,14 @@ class Block(object):
                 cb_indent = indent
 
             if indent < cb_indent and not is_empty(line):
+                text = ("\n".join(l[cb_indent:] for l in lines[cb_start:i]))
+                text = text[1:]     # Remove first newline
+
                 blocks.append(CodeBlock(
                     rst_file,
                     cb_start,
                     i,
-                    "\n".join(l[cb_indent:] for l in lines[cb_start:i]),
+                    text,
                     lang,
                     project,
                     main_file,

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -791,6 +791,8 @@ def analyze_file(rst_file):
                 except S.CalledProcessError as e:
                     out = str(e.output.decode("utf-8"))
 
+            output_block_info(block)
+
             if args.all_diagnostics:
                 print_diags()
 

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -32,6 +32,7 @@ import colors as C
 import shutil
 import glob
 import re
+import hashlib
 from widget.chop import manual_chop, cheapo_gnatchop, real_gnatchop
 
 
@@ -183,6 +184,10 @@ class CodeBlock(Block):
         self.buttons = buttons
         self.run = True
 
+        # Hash of source-code
+        str_text = str(self.text).encode("utf-8")
+        self.text_hash: str = hashlib.sha512(str_text).hexdigest()
+        self.text_hash_short: str = hashlib.md5(str_text).hexdigest()
 
 class ConfigBlock(Block):
     def __init__(self, **opts):

--- a/frontend/tests/compile_blocks.py
+++ b/frontend/tests/compile_blocks.py
@@ -33,6 +33,7 @@ import shutil
 import glob
 import re
 import hashlib
+import json
 from widget.chop import manual_chop, cheapo_gnatchop, real_gnatchop
 
 
@@ -361,6 +362,17 @@ def analyze_file(rst_file):
             raise e
 
         return output
+
+    def output_block_info(block):
+        block_info = vars(block)
+
+        with open('block_info.json', u'w') as f:
+            json.dump(block_info, f, indent=4)
+
+        block_info_json_file = "block_info.json"
+        if os.path.isfile(block_info_json_file):
+            with open(block_info_json_file, u'r') as f:
+                block_info_json = json.load(f)
 
     if args.code_block_at:
         for i, block in code_blocks:


### PR DESCRIPTION
- Writing separate directories for code blocks.
- Directories named by MD5 hash.
- Writing JSON file containing code block information.

Ref #626