### PR TITLE
Editorial changes: preparations for Advanced Ada publication

### DIFF
--- a/content/courses/advanced-ada/index.rst
+++ b/content/courses/advanced-ada/index.rst
@@ -104,7 +104,7 @@ Advanced Journey With Ada: A Flight In Progress
 
     This course will teach you advanced topics of the Ada programming language.
     The
-    :doc:`Introduction to Ada </courses/intro-to-ada/index>`
+    :doc:`Introduction to Ada <learn:courses/intro-to-ada/index>`
     course is a prerequisite for this course.
 
     .. only:: not no_hidden_books

--- a/content/courses/advanced-ada/index.rst
+++ b/content/courses/advanced-ada/index.rst
@@ -104,7 +104,7 @@ Advanced Journey With Ada: A Flight In Progress
 
     This course will teach you advanced topics of the Ada programming language.
     The
-    :doc:`Introduction to Ada <learn:courses/intro-to-ada/index>`
+    :ref:`Introduction to Ada <Intro_Ada_Course_Index>`
     course is a prerequisite for this course.
 
     .. only:: not no_hidden_books

--- a/content/courses/advanced-ada/index.rst
+++ b/content/courses/advanced-ada/index.rst
@@ -20,7 +20,7 @@ Advanced Journey With Ada: A Flight In Progress
 
     .. container:: content-copyright
 
-        Copyright © 2019 |ndash| 2022, AdaCore
+        Copyright © 2019 |ndash| 2023, AdaCore
 
         This book is published under a CC BY-SA license, which means that you
         can copy, redistribute, remix, transform, and build upon the content
@@ -126,7 +126,7 @@ Advanced Journey With Ada: A Flight In Progress
 
     .. admonition:: CHANGELOG
 
-        *Release 2023-04*
+        *Release 2023-05*
 
         - First draft release including following chapters:
 

--- a/content/courses/advanced-ada/index.rst
+++ b/content/courses/advanced-ada/index.rst
@@ -128,7 +128,7 @@ Advanced Journey With Ada: A Flight In Progress
 
         *Release 2023-05*
 
-        - First draft release including following chapters:
+        - First draft release including following parts:
 
             - Data Types
             - Control Flow

--- a/content/courses/advanced-ada/index.rst
+++ b/content/courses/advanced-ada/index.rst
@@ -151,7 +151,7 @@ Advanced Journey With Ada: A Flight In Progress
 
 .. toctree::
     :maxdepth: 4
-    :caption: Contents:
+    :caption: Contents
 
     parts/data_types/index
     parts/control_flow/index
@@ -161,7 +161,7 @@ Advanced Journey With Ada: A Flight In Progress
 
     .. toctree::
         :maxdepth: 4
-        :caption: Contents:
+        :caption: Contents
 
         parts/resource_management/index
         parts/abstraction-oriented_prog/index

--- a/content/courses/advanced-ada/parts/abstraction-oriented_prog/generics.rst
+++ b/content/courses/advanced-ada/parts/abstraction-oriented_prog/generics.rst
@@ -1318,7 +1318,7 @@ Formal incomplete type
 .. admonition:: Relevant topics
 
     - Formal incomplete type mentioned in
-      :arm:`Formal Types <12-5>`
+      :arm22:`Formal Types <12-5>`
 
 .. todo::
 
@@ -1331,7 +1331,7 @@ Default subtype mark
 .. admonition:: Relevant topics
 
     - Default subtype mark (:ada:`or use`) mentioned in
-      :arm:`Formal Types <12-5>`
+      :arm22:`Formal Types <12-5>`
 
 .. todo::
 
@@ -1343,7 +1343,7 @@ Formal private and derived types
 
 .. admonition:: Relevant topics
 
-    - :arm:`Formal Private and Derived Types <12-5-1>`
+    - :arm22:`Formal Private and Derived Types <12-5-1>`
 
 .. todo::
 
@@ -2832,7 +2832,7 @@ Generic Renaming
 
 .. admonition:: Relevant topics
 
-    - :arm:`Generic Renaming Declarations <8-5-5>`
+    - :arm22:`Generic Renaming Declarations <8-5-5>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/abstraction-oriented_prog/oo_prog.rst
+++ b/content/courses/advanced-ada/parts/abstraction-oriented_prog/oo_prog.rst
@@ -18,7 +18,7 @@ Overriding indicators
 
     - **Briefly** discuss :ada:`overriding` and :ada:`not overriding` mentioned
       in
-      :arm:`Overriding Indicators <8-3-1>`
+      :arm22:`Overriding Indicators <8-3-1>`
     - Mention that :ada:`not overriding` is not recommended.
 
 .. todo::
@@ -790,7 +790,7 @@ User-defined indexing
 
 .. admonition:: Relevant topics
 
-   - :arm:`User-Defined Indexing <4-1-6>`
+   - :arm22:`User-Defined Indexing <4-1-6>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/appendices/legacy.rst
+++ b/content/courses/advanced-ada/parts/appendices/legacy.rst
@@ -159,7 +159,7 @@ This is the test application in this case:
 
 .. admonition:: Relevant topics
 
-    - :arm:`Subunits of Compilation Units <10-1-3>`
+    - :arm22:`Subunits of Compilation Units <10-1-3>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/control_flow/exceptions.rst
+++ b/content/courses/advanced-ada/parts/control_flow/exceptions.rst
@@ -79,7 +79,7 @@ roughly corresponds to this:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.4.2 Pragmas Assert and Assertion_Policy <11-4-2>`
+    - :arm22:`11.4.2 Pragmas Assert and Assertion_Policy <11-4-2>`
 
 
 Assertion policies
@@ -228,7 +228,7 @@ the call to :ada:`Assert` is not ignored.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.4.2 Pragmas Assert and Assertion_Policy <11-4-2>`
+    - :arm22:`11.4.2 Pragmas Assert and Assertion_Policy <11-4-2>`
 
 
 ..
@@ -842,7 +842,7 @@ checks fails and raises a :ada:`Storage_Error` exception.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.5 Suppressing Checks <11-5>`
+    - :arm22:`11.5 Suppressing Checks <11-5>`
 
 
 ``Ada.Exceptions`` package
@@ -886,7 +886,7 @@ that raises the exception, as in the following code:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.4.1 The Package Exceptions <11-4-1>`
+    - :arm22:`11.4.1 The Package Exceptions <11-4-1>`
 
 
 Retrieving exception information
@@ -1357,7 +1357,7 @@ package.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`8.5.2 Exception Renaming Declarations <8-5-2>`
+    - :arm22:`8.5.2 Exception Renaming Declarations <8-5-2>`
 
 
 Out and Uninitialized
@@ -1530,7 +1530,7 @@ In the case of direct assignments to global variables, the behavior in the
 presence of exceptions is somewhat different. For predefined exceptions, most
 notably :ada:`Constraint_Error`, the optimization permissions allow some
 flexibility in whether a global variable is or is not updated when an exception
-occurs (see :arm:`Ada RM 11.6 <11-6>`). For
+occurs (see :arm22:`Ada RM 11.6 <11-6>`). For
 instance, the following code makes an incorrect assumption:
 
 .. code-block:: none
@@ -1545,7 +1545,7 @@ program are incorrect code which should be fixed.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.6 Exceptions and Optimization <11-6>`
+    - :arm22:`11.6 Exceptions and Optimization <11-6>`
 
 
 Suppressing checks
@@ -1768,4 +1768,4 @@ the call to this function, which raises a :ada:`Constraint_Error` exception.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`11.5 Suppressing Checks <11-5>`
+    - :arm22:`11.5 Suppressing Checks <11-5>`

--- a/content/courses/advanced-ada/parts/control_flow/expressions.rst
+++ b/content/courses/advanced-ada/parts/control_flow/expressions.rst
@@ -13,7 +13,7 @@ at compile-time.
 
 Even though the definition above is very simple, Ada expressions are actually
 very flexible |mdash| and they can also be very complex. In fact, if you read
-the :arm:`corresponding section <4-4>` of the Ada Reference Manual, you'll
+the :arm22:`corresponding section <4-4>` of the Ada Reference Manual, you'll
 quickly discover that they include elements such as relations, membership
 choices, terms and primaries. Some of these are classic elements of expressions
 in programming languages, although some of their forms are unique to Ada. In
@@ -22,7 +22,7 @@ complete overview, please refer to the Reference Manual.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.4 Expressions <4-4>`
+    - :arm22:`4.4 Expressions <4-4>`
 
 
 Relations and simple expressions
@@ -184,12 +184,12 @@ a membership choice list, and :ada:`Off` and :ada:`A` are membership choices.
            | raise_expression
 
     Again, for more details, please refer to the
-    :arm:`section on expressions <4-4>` of the Ada Reference Manual.
+    :arm22:`section on expressions <4-4>` of the Ada Reference Manual.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.4 Expressions <4-4>`
-    - :arm:`4.5.2 Relational Operators and Membership Tests <4-5-2>`
+    - :arm22:`4.4 Expressions <4-4>`
+    - :arm22:`4.5.2 Relational Operators and Membership Tests <4-5-2>`
 
 
 Numeric expressions
@@ -246,7 +246,7 @@ each:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.4 Expressions <4-4>`
+    - :arm22:`4.4 Expressions <4-4>`
 
 
 Other expressions
@@ -257,7 +257,7 @@ Indeed, expressions can be of any type, and the definition of primaries we've
 seen earlier on already hints in this direction |mdash| as it includes elements
 such as allocators. Because expressions are very flexible, covering all possible
 variations and combinations in this section is out of scope. Again, please refer
-to the :arm:`section on expressions <4-4>` of the Ada Reference Manual for
+to the :arm22:`section on expressions <4-4>` of the Ada Reference Manual for
 further details.
 
 
@@ -524,7 +524,7 @@ semicolons.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.5.7 Conditional Expressions <4-5-7>`
+    - :arm22:`4.5.7 Conditional Expressions <4-5-7>`
 
 .. _Adv_Ada_Quantified_Expressions:
 
@@ -728,7 +728,7 @@ comparing them against zero.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.5.8 Quantified Expressions <4-5-8>`
+    - :arm22:`4.5.8 Quantified Expressions <4-5-8>`
 
 
 .. _Adv_Ada_Declare_Expressions:

--- a/content/courses/advanced-ada/parts/control_flow/expressions.rst
+++ b/content/courses/advanced-ada/parts/control_flow/expressions.rst
@@ -3,6 +3,9 @@ Expressions
 
 .. include:: ../../../global.txt
 
+
+.. _Adv_Ada_Expressions:
+
 Expressions: Definition
 -----------------------
 
@@ -353,11 +356,8 @@ expression, a term, a factor and a primary.
 However, if we replace :ada:`case M1 is` by :ada:`case (M1) is`, :ada:`(M1)`
 is identified as a parenthesized expression, not as a name! This parenthesized
 expression is first parsed and evaluated, which might have implications in case
-statements, as we'll see in another chapter.
-
-.. todo::
-
-    Add link to subsection on case statements and expressions.
+statements, as we'll see
+:ref:`in another chapter <Adv_Ada_Case_Statements_And_Expressions>`.
 
 Let's look at another example, this time with a subprogram call:
 

--- a/content/courses/advanced-ada/parts/control_flow/statements.rst
+++ b/content/courses/advanced-ada/parts/control_flow/statements.rst
@@ -24,7 +24,7 @@ Here are some examples from each category:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`5.1 Simple and Compound Statements - Sequences of Statements <5-1>`
+    - :arm22:`5.1 Simple and Compound Statements - Sequences of Statements <5-1>`
 
 Labels
 ------
@@ -56,7 +56,7 @@ statement.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`5.1 Simple and Compound Statements - Sequences of Statements <5-1>`
+    - :arm22:`5.1 Simple and Compound Statements - Sequences of Statements <5-1>`
 
 Labels and :ada:`goto` statements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -331,7 +331,7 @@ condition :ada:`Cond` is met, even if we're actually within the inner loop.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`5.7 Exit Statements <5-7>`
+    - :arm22:`5.7 Exit Statements <5-7>`
 
 
 If, case and loop statements
@@ -387,9 +387,9 @@ statement.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`5.3 If Statements <5-3>`
-    - :arm:`5.4 Case Statements <5-4>`
-    - :arm:`5.5 Loop Statements <5-5>`
+    - :arm22:`5.3 If Statements <5-3>`
+    - :arm22:`5.4 Case Statements <5-4>`
+    - :arm22:`5.5 Loop Statements <5-5>`
 
 Case statements and expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -561,7 +561,7 @@ Block statement identifiers are useful:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`5.6 Block Statements <5-6>`
+    - :arm22:`5.6 Block Statements <5-6>`
 
 ..
     REMOVED! TO BE RE-EVALUATED IN 2025:
@@ -636,7 +636,7 @@ as the function result.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.5 Return Statements <6-5>`
+    - :arm22:`6.5 Return Statements <6-5>`
 
 
 Other usages of extended return statements

--- a/content/courses/advanced-ada/parts/control_flow/statements.rst
+++ b/content/courses/advanced-ada/parts/control_flow/statements.rst
@@ -391,6 +391,8 @@ statement.
     - :arm22:`5.4 Case Statements <5-4>`
     - :arm22:`5.5 Loop Statements <5-5>`
 
+.. _Adv_Ada_Case_Statements_And_Expressions:
+
 Case statements and expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -399,14 +401,11 @@ As we know, the case statement has a choice expression
 Also, this expression can be a function call or a type conversion, for example
 |mdash| in additional to being a variable or a constant.
 
-As we discussed earlier on, if we use parentheses, the contents between those
+As we discussed :ref:`earlier on <Adv_Ada_Parenthesized_Expressions>`,
+if we use parentheses, the contents between those
 parentheses is parsed as an expression. In the context of case statements, the
 expression is first evaluated before being used as a choice expression. Consider
 the following code example:
-
-.. todo::
-
-    Add link to Adv_Ada_Parenthesized_Expressions when it's available
 
 .. code:: ada run_button project=Courses.Advanced_Ada.Control_Flow.Statements.If_Case_Loop_Statements.Case_Statement_Expression
     :class: ada-expect-compile-error

--- a/content/courses/advanced-ada/parts/control_flow/subprograms.rst
+++ b/content/courses/advanced-ada/parts/control_flow/subprograms.rst
@@ -25,8 +25,8 @@ specification or body.
 
 .. admonition:: In the Ada Reference Manual
 
-   - :arm:`6.2 Formal Parameter Modes <6-2>`
-   - :arm:`6.4.1 Parameter Associations <6-4-1>`
+   - :arm22:`6.2 Formal Parameter Modes <6-2>`
+   - :arm22:`6.4.1 Parameter Associations <6-4-1>`
 
 
 Formal Parameter Modes
@@ -468,7 +468,7 @@ about how this association is made and some of the potential errors.
 
 .. admonition:: In the Ada Reference Manual
 
-   - :arm:`6.4.1 Parameter Associations <6-4-1>`
+   - :arm22:`6.4.1 Parameter Associations <6-4-1>`
 
 
 Parameter order and association
@@ -689,7 +689,7 @@ Many primitive operators exist for scalar types. We classify them as follows:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.5 Operators and Expression Evaluation <4-5>`
+    - :arm22:`4.5 Operators and Expression Evaluation <4-5>`
 
 User-defined operators
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -974,7 +974,7 @@ In this example, we're using the primitive :ada:`=` operator for the
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.1 Subprogram Declarations <6-1>`
+    - :arm22:`6.1 Subprogram Declarations <6-1>`
 
 Expression functions
 --------------------
@@ -1134,7 +1134,7 @@ instead:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.8 Expression functions <6-8>`
+    - :arm22:`6.8 Expression functions <6-8>`
 
 
 .. _Adv_Ada_Overloading:
@@ -1405,8 +1405,8 @@ package.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.6 Overloading of Operators <6-6>`
-    - :arm:`G.1.1 Complex Types <G-1-1>`
+    - :arm22:`6.6 Overloading of Operators <6-6>`
+    - :arm22:`G.1.1 Complex Types <G-1-1>`
 
 Operator Overriding
 -------------------
@@ -1683,7 +1683,7 @@ Here, :ada:`Program_Error` is raised when :ada:`Log_And_Raise` returns to the
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.5.1 Nonreturning Subprograms <6-5-1>`
+    - :arm22:`6.5.1 Nonreturning Subprograms <6-5-1>`
 
 
 Inline subprograms
@@ -1798,7 +1798,7 @@ instances of that generic subprogram.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.3.2 Inline Expansion of Subprograms <6-3-2>`
+    - :arm22:`6.3.2 Inline Expansion of Subprograms <6-3-2>`
 
 
 .. _Adv_Ada_Null_Procedures:
@@ -1952,4 +1952,4 @@ that makes use of null procedures.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.7 Null Procedures <6-7>`
+    - :arm22:`6.7 Null Procedures <6-7>`

--- a/content/courses/advanced-ada/parts/data_types/aggregates.rst
+++ b/content/courses/advanced-ada/parts/data_types/aggregates.rst
@@ -153,7 +153,7 @@ defining custom container aggregates for any record type.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.3.5 Container Aggregates <4-3-5>`
+    - :arm22:`4.3.5 Container Aggregates <4-3-5>`
 
 
 .. _Adv_Ada_Record_Aggregates:
@@ -267,7 +267,7 @@ Here, we assign 5 to both :ada:`X` and :ada:`Y`.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.3.1 Record Aggregates <4-3-1>`
+    - :arm22:`4.3.1 Record Aggregates <4-3-1>`
 
 
 :ada:`<>`
@@ -698,7 +698,7 @@ subprograms for it. For example, we could specify an addition operation for it:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.3.1 Record Aggregates <4-3-1>`
+    - :arm22:`4.3.1 Record Aggregates <4-3-1>`
 
 Simple Prototyping
 ~~~~~~~~~~~~~~~~~~
@@ -1207,7 +1207,7 @@ this section just presents some details about this topic.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.3.3 Array Aggregates <4-3-3>`
+    - :arm22:`4.3.3 Array Aggregates <4-3-3>`
 
 Positional and named array aggregates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2076,7 +2076,7 @@ ancestor type's components.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.3.2 Extension Aggregates <4-3-2>`
+    - :arm22:`4.3.2 Extension Aggregates <4-3-2>`
 
 Assignments to objects of derived types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/content/courses/advanced-ada/parts/data_types/arrays.rst
+++ b/content/courses/advanced-ada/parts/data_types/arrays.rst
@@ -56,7 +56,7 @@ its whole lifetime.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.6 Array Types <3-6>`
+    - :arm22:`3.6 Array Types <3-6>`
 
 
 Unconstrained Arrays vs. Vectors
@@ -119,8 +119,8 @@ once for each object.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.6 Array Types <3-6>`
-    - :arm:`A.18.2 The Generic Package Containers.Vectors <A-18-2>`
+    - :arm22:`3.6 Array Types <3-6>`
+    - :arm22:`A.18.2 The Generic Package Containers.Vectors <A-18-2>`
 
 
 Multidimensional Arrays
@@ -326,7 +326,7 @@ to highlight the following aspects:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.6 Array Types <3-6>`
+    - :arm22:`3.6 Array Types <3-6>`
 
 
 Unconstrained Multidimensional Arrays

--- a/content/courses/advanced-ada/parts/data_types/numerics.rst
+++ b/content/courses/advanced-ada/parts/data_types/numerics.rst
@@ -24,7 +24,7 @@ and :ada:`Mod`. We also discuss operations on modular types.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5.4 Integer Types <3-5-4>`
+    - :arm22:`3.5.4 Integer Types <3-5-4>`
 
 
 :ada:`Modulus` Attribute
@@ -638,8 +638,8 @@ In this section, we discuss various attributes related to floating-point types.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5.8 Operations of Floating Point Types <3-5-8>`
-    - :arm:`A.5.3 Attributes of Floating Point Types <A-5-3>`
+    - :arm22:`3.5.8 Operations of Floating Point Types <3-5-8>`
+    - :arm22:`A.5.3 Attributes of Floating Point Types <A-5-3>`
 
 Representation-oriented attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1290,7 +1290,7 @@ This is the reason why we see 1.3008896 x 10\ :sup:`7` instead of
 
     .. admonition:: In the Ada Reference Manual
 
-        - :arm:`G.2.1 Model of Floating Point Arithmetic <G-2-1>`
+        - :arm22:`G.2.1 Model of Floating Point Arithmetic <G-2-1>`
 
     Attributes: :ada:`'Model_Mantissa`, :ada:`'Model_Emin`
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1500,8 +1500,8 @@ fixed-point types.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5.10 Operations of Fixed Point Types <3-5-10>`
-    - :arm:`A.5.4 Attributes of Fixed Point Types <A-5-4>`
+    - :arm22:`3.5.10 Operations of Fixed Point Types <3-5-10>`
+    - :arm22:`A.5.4 Attributes of Fixed Point Types <A-5-4>`
 
 Attributes of fixed-point types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/content/courses/advanced-ada/parts/data_types/numerics.rst
+++ b/content/courses/advanced-ada/parts/data_types/numerics.rst
@@ -1951,7 +1951,7 @@ package:
 | Big Reals    | :ada:`Ada.Numerics.Big_Numbers.Big_Real`     |
 +--------------+----------------------------------------------+
 
-.. admonition:: Relevant topics
+.. admonition:: In the Ada Reference Manual
 
     - :arm22:`Big Numbers <A-5-5>`
     - :arm22:`Big Integers <A-5-6>`

--- a/content/courses/advanced-ada/parts/data_types/strings.rst
+++ b/content/courses/advanced-ada/parts/data_types/strings.rst
@@ -126,7 +126,7 @@ best choice, as it covers all possible use-cases.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.6.3 String Types <3-6-3>`
+    - :arm22:`3.6.3 String Types <3-6-3>`
 
 Text I/O
 ~~~~~~~~
@@ -192,11 +192,11 @@ and :ada:`Float_IO`:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`A.10 Text Input-Output <A-10>`
-    - :arm:`A.10.1 The Package Text_IO <A-10-1>`
-    - :arm:`A.10.8 Input-Output for Integer Types <A-10-8>`
-    - :arm:`A.10.9 Input-Output for Real Types <A-10-9>`
-    - :arm:`A.11 Wide Text Input-Output and Wide Wide Text Input-Output <A-11>`
+    - :arm22:`A.10 Text Input-Output <A-10>`
+    - :arm22:`A.10.1 The Package Text_IO <A-10-1>`
+    - :arm22:`A.10.8 Input-Output for Integer Types <A-10-8>`
+    - :arm22:`A.10.9 Input-Output for Real Types <A-10-9>`
+    - :arm22:`A.11 Wide Text Input-Output and Wide Wide Text Input-Output <A-11>`
 
 
 Wide and Wide-Wide String Handling
@@ -275,9 +275,9 @@ attribute :ref:`later on <Adv_Ada_Wider_Versions_Image_Attribute>`.)
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`A.4.6 String-Handling Sets and Mappings <A-4-6>`
-    - :arm:`A.4.7 Wide_String Handling <A-4-7>`
-    - :arm:`A.4.8 Wide_Wide_String Handling <A-4-8>`
+    - :arm22:`A.4.6 String-Handling Sets and Mappings <A-4-6>`
+    - :arm22:`A.4.7 Wide_String Handling <A-4-7>`
+    - :arm22:`A.4.8 Wide_Wide_String Handling <A-4-8>`
 
 
 Bounded and Unbounded Wide and Wide-Wide Strings
@@ -349,9 +349,9 @@ All the operations we're using here are similar to the ones for
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`A.4.7 Wide_String Handling <A-4-7>`
-    - :arm:`A.4.8 Wide_Wide_String Handling <A-4-8>`
-    - :arm:`A.11 Wide Text Input-Output and Wide Wide Text Input-Output <A-11>`
+    - :arm22:`A.4.7 Wide_String Handling <A-4-7>`
+    - :arm22:`A.4.8 Wide_Wide_String Handling <A-4-8>`
+    - :arm22:`A.11 Wide Text Input-Output and Wide Wide Text Input-Output <A-11>`
 
 
 String Encoding
@@ -366,7 +366,7 @@ and other requirements.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`A.4.11 String Encoding <A-4-11>`
+    - :arm22:`A.4.11 String Encoding <A-4-11>`
 
 UTF-8 encoding and decoding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/content/courses/advanced-ada/parts/data_types/types.rst
+++ b/content/courses/advanced-ada/parts/data_types/types.rst
@@ -1747,11 +1747,8 @@ Ada distinguishes between two kinds of conversion: value conversion and view
 conversion. The main difference is the way how the operand (argument) of the
 conversion is evaluated:
 
-- in a value conversion, the operand is evaluated as an expression;
-
-.. todo::
-
-    Add link to section about expressions once it's available!
+- in a value conversion, the operand is evaluated as an
+  :ref:`expression <Adv_Ada_Expressions>`;
 
 - in a view conversion, the operand is evaluated as a name.
 

--- a/content/courses/advanced-ada/parts/data_types/types.rst
+++ b/content/courses/advanced-ada/parts/data_types/types.rst
@@ -55,7 +55,7 @@ course.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5 Scalar types <3-5>`
+    - :arm22:`3.5 Scalar types <3-5>`
 
 Ranges
 ~~~~~~
@@ -540,7 +540,7 @@ enumeration renaming, enumeration overloading and representation clauses.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5.1 Enumeration Types <3-5-1>`
+    - :arm22:`3.5.1 Enumeration Types <3-5-1>`
 
 Enumerations as functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1177,7 +1177,7 @@ We'll see later how definite and indefinite types apply to
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.3 Objects and Named Numbers <3-3>`
+    - :arm22:`3.3 Objects and Named Numbers <3-3>`
 
 Constrained Attribute
 ~~~~~~~~~~~~~~~~~~~~~
@@ -1338,7 +1338,7 @@ the value of the :ada:`Extended` discriminant). Therefore, with the call to
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.7.2 Operations of Discriminated Types <3-7-2>`
+    - :arm22:`3.7.2 Operations of Discriminated Types <3-7-2>`
 
 
 .. _Adv_Ada_Incomplete_Types:
@@ -1431,7 +1431,7 @@ we'll discuss :ref:`later <Adv_Ada_Formal_Incomplete_Types>`.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10.1 Incomplete Type Declarations <3-10-1>`
+    - :arm22:`3.10.1 Incomplete Type Declarations <3-10-1>`
 
 
 .. _Adv_Ada_Mutually_Dependent_Types:
@@ -1523,7 +1523,7 @@ Later on, we'll see that these code examples can be written using
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10.1 Incomplete Type Declarations <3-10-1>`
+    - :arm22:`3.10.1 Incomplete Type Declarations <3-10-1>`
 
 
 .. _Adv_Ada_Type_View:
@@ -1729,7 +1729,7 @@ want to declare objects of this type.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`7.3 Private Types and Private Extensions <7-3>`
+    - :arm22:`7.3 Private Types and Private Extensions <7-3>`
 
 
 Type conversion
@@ -1760,7 +1760,7 @@ conversion, but only :ada:`A`. In a value conversion, we could use both forms.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.6 Type Conversions <4-6>`
+    - :arm22:`4.6 Type Conversions <4-6>`
 
 
 Value conversion
@@ -2733,7 +2733,7 @@ Here, :ada:`Int'(0)` indicates that the value zero is of :ada:`Int` type.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.7 Qualified Expressions <4-7>`
+    - :arm22:`4.7 Qualified Expressions <4-7>`
 
 
 Verifying subtypes
@@ -2885,8 +2885,8 @@ default values, since we haven't assigned any value to them.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.5 Scalar Types <3-5>`
-    - :arm:`3.6 Array Types <3-6>`
+    - :arm22:`3.5 Scalar Types <3-5>`
+    - :arm22:`3.6 Array Types <3-6>`
 
 
 Deferred Constants
@@ -3015,7 +3015,7 @@ declaration of the :ada:`Light` constant.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`7.4 Deferred Constants <7-4>`
+    - :arm22:`7.4 Deferred Constants <7-4>`
 
 
 .. _Adv_Ada_User_Defined_Literals:
@@ -3396,5 +3396,5 @@ when using a preprocessor or a domain-specific language.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.2.1 User-Defined Literals <4-2-1>`
+    - :arm22:`4.2.1 User-Defined Literals <4-2-1>`
 

--- a/content/courses/advanced-ada/parts/data_types/types_representation.rst
+++ b/content/courses/advanced-ada/parts/data_types/types_representation.rst
@@ -95,13 +95,8 @@ strict requirements that are often found there. Therefore, unless you have
 very specific requirements for your application, in most cases, you won't need
 them. However, you should at least have a rudimentary understanding of them.
 To read a thorough overview on this topic, please refer to the
-*Introduction to Embedded Systems Programming* course.
-
-.. todo::
-
-    Add link once available:
-
-    ``Introduction to Embedded Systems Programming </courses/intro-to-embedded-sys-prog/low_level_programming>``
+:doc:`Introduction to Embedded Systems Programming <learn:courses/intro-to-embedded-sys-prog/chapters/low_level_programming>`
+course.
 
 .. admonition:: In the Ada Reference Manual
 
@@ -1039,7 +1034,8 @@ In this section, we discuss how to use record representation clauses to specify
 how a record is represented in memory. Our goal is to provide a brief
 introduction into the topic. If you're interested in more details, you can find
 a thorough discussion about record representation clauses in the
-*Introduction to Embedded Systems Programming* course.
+:doc:`Introduction to Embedded Systems Programming <learn:courses/intro-to-embedded-sys-prog/chapters/low_level_programming>`
+course.
 
 Let's start with the simple approach of declaring a record type without
 providing further information. In this case, we're basically asking the

--- a/content/courses/advanced-ada/parts/data_types/types_representation.rst
+++ b/content/courses/advanced-ada/parts/data_types/types_representation.rst
@@ -105,9 +105,9 @@ To read a thorough overview on this topic, please refer to the
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`13.2 Packed Types <13-2>`
-    - :arm:`13.3 Operational and Representation Attributes <13-3>`
-    - :arm:`13.5.3 Bit Ordering <13-5-3>`
+    - :arm22:`13.2 Packed Types <13-2>`
+    - :arm22:`13.3 Operational and Representation Attributes <13-3>`
+    - :arm22:`13.5.3 Bit Ordering <13-5-3>`
 
 Sizes
 ~~~~~
@@ -1152,7 +1152,7 @@ bits span over four storage units (positions #0 .. #3).
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`13.5.1 Record Representation Clauses <13-5-1>`
+    - :arm22:`13.5.1 Record Representation Clauses <13-5-1>`
 
 Storage Place Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1243,7 +1243,7 @@ seen above.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`13.5.2 Storage Place Attributes <13-5-2>`
+    - :arm22:`13.5.2 Storage Place Attributes <13-5-2>`
 
 Using Representation Clauses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2007,7 +2007,7 @@ when we know that information stored in memory might be corrupted.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`13.9.2 The Valid Attribute <13-9-2>`
+    - :arm22:`13.9.2 The Valid Attribute <13-9-2>`
 
 Unchecked Union
 ---------------
@@ -2274,7 +2274,7 @@ solving very specific problems when doing low-level programming.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`B.3.3 Unchecked Union Types <B-3-3>`
+    - :arm22:`B.3.3 Unchecked Union Types <B-3-3>`
 
 Shared variable control
 -----------------------
@@ -2284,7 +2284,7 @@ start by discussing volatile objects.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`C.6 Shared Variable Control <C-6>`
+    - :arm22:`C.6 Shared Variable Control <C-6>`
 
 Volatile
 ~~~~~~~~

--- a/content/courses/advanced-ada/parts/data_types/types_representation.rst
+++ b/content/courses/advanced-ada/parts/data_types/types_representation.rst
@@ -95,7 +95,7 @@ strict requirements that are often found there. Therefore, unless you have
 very specific requirements for your application, in most cases, you won't need
 them. However, you should at least have a rudimentary understanding of them.
 To read a thorough overview on this topic, please refer to the
-:doc:`Introduction to Embedded Systems Programming <learn:courses/intro-to-embedded-sys-prog/chapters/low_level_programming>`
+:ref:`Introduction to Embedded Systems Programming <Intro_Embedded_Sys_Prog_Low_Level_Programming>`
 course.
 
 .. admonition:: In the Ada Reference Manual
@@ -1034,7 +1034,7 @@ In this section, we discuss how to use record representation clauses to specify
 how a record is represented in memory. Our goal is to provide a brief
 introduction into the topic. If you're interested in more details, you can find
 a thorough discussion about record representation clauses in the
-:doc:`Introduction to Embedded Systems Programming <learn:courses/intro-to-embedded-sys-prog/chapters/low_level_programming>`
+:ref:`Introduction to Embedded Systems Programming <Intro_Embedded_Sys_Prog_Low_Level_Programming>`
 course.
 
 Let's start with the simple approach of declaring a record type without

--- a/content/courses/advanced-ada/parts/design_by_contracts/contracts.rst
+++ b/content/courses/advanced-ada/parts/design_by_contracts/contracts.rst
@@ -16,7 +16,7 @@ Default initial conditions
 
 .. admonition:: Relevant topics
 
-    - :arm:`Default Initial Conditions <7-3-3>`
+    - :arm22:`Default Initial Conditions <7-3-3>`
 
 .. todo::
 
@@ -29,7 +29,7 @@ Entry index attribute
 .. admonition:: Relevant topics
 
     - :ada:`E'Index` mentioned in
-      :arm:`Preconditions and Postconditions <6-1-1>`
+      :arm22:`Preconditions and Postconditions <6-1-1>`
 
 .. todo::
 
@@ -54,7 +54,7 @@ Predicate failure
 .. admonition:: Relevant topics
 
     - :ada:`Predicate_Failure` mentioned in
-      :arm:`Subtype Predicates <3-2-4>`
+      :arm22:`Subtype Predicates <3-2-4>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/initialization/elaboration_of_generics.rst
+++ b/content/courses/advanced-ada/parts/initialization/elaboration_of_generics.rst
@@ -9,7 +9,7 @@ Elaboration check
 .. admonition:: Relevant topics
 
     - Elaboration check mentioned in
-      :arm:`Generic Bodies <12-2>`
+      :arm22:`Generic Bodies <12-2>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/initialization/freezing.rst
+++ b/content/courses/advanced-ada/parts/initialization/freezing.rst
@@ -8,7 +8,7 @@ Freezing rules
 
 .. admonition:: Relevant topics
 
-    - :arm:`Freezing rules <13-14>`
+    - :arm22:`Freezing rules <13-14>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/initialization/package_elaboration.rst
+++ b/content/courses/advanced-ada/parts/initialization/package_elaboration.rst
@@ -11,7 +11,7 @@ Preelaboration
 .. admonition:: Relevant topics
 
     - Pure packages
-    - :arm:`Preelaboration Requirements <C-4>`
+    - :arm22:`Preelaboration Requirements <C-4>`
 
 .. todo::
 
@@ -23,8 +23,8 @@ Elaboration control
 
 .. admonition:: Relevant topics
 
-    - :arm:`Elaboration control <10-2-1>`
-    - :arm:`Elaboration Control Pragmas <J-15-14>`
+    - :arm22:`Elaboration control <10-2-1>`
+    - :arm22:`Elaboration Control Pragmas <J-15-14>`
     - GNAT's static model
 
 .. todo::

--- a/content/courses/advanced-ada/parts/initialization/package_elaboration.rst
+++ b/content/courses/advanced-ada/parts/initialization/package_elaboration.rst
@@ -30,3 +30,20 @@ Elaboration control
 .. todo::
 
     Complete section!
+
+
+.. _Adv_Ada_Pure:
+
+Pure program and library units
+------------------------------
+
+.. admonition:: Relevant topics
+
+    - :arm22:`C.4 Preelaboration Requirements <C-4>`
+    - :arm22:`10.2.1 Elaboration Control <10-2-1>`
+    - Add link to :ref:`Adv_Ada_Preelaboration` section
+
+.. todo::
+
+    Complete section!
+

--- a/content/courses/advanced-ada/parts/modular_prog/packages.rst
+++ b/content/courses/advanced-ada/parts/modular_prog/packages.rst
@@ -184,7 +184,7 @@ proceed with the discussion, let's recapitulate some important ideas that we've
 seen earlier.
 
 In the
-:doc:`Introduction to Ada course </courses/intro-to-ada/chapters/privacy>`,
+:doc:`Introduction to Ada course <learn:courses/intro-to-ada/chapters/privacy>`,
 we've seen that encapsulation plays an important role in modular programming.
 By using the private part of a package specification, we can disclose some
 information, but, at the same time, prevent that this information gets

--- a/content/courses/advanced-ada/parts/modular_prog/packages.rst
+++ b/content/courses/advanced-ada/parts/modular_prog/packages.rst
@@ -184,7 +184,7 @@ proceed with the discussion, let's recapitulate some important ideas that we've
 seen earlier.
 
 In the
-:doc:`Introduction to Ada course <learn:courses/intro-to-ada/chapters/privacy>`,
+:ref:`Introduction to Ada course <Intro_Ada_Course_Privacy>`,
 we've seen that encapsulation plays an important role in modular programming.
 By using the private part of a package specification, we can disclose some
 information, but, at the same time, prevent that this information gets

--- a/content/courses/advanced-ada/parts/modular_prog/packages.rst
+++ b/content/courses/advanced-ada/parts/modular_prog/packages.rst
@@ -29,7 +29,7 @@ that we can :ref:`rename packages <Intro_Ada_Package_Renaming>`.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`10.1.1 Compilation Units - Library Units <10-1-1>`
+    - :arm22:`10.1.1 Compilation Units - Library Units <10-1-1>`
 
 
 Grouping packages
@@ -529,7 +529,7 @@ Note that subprograms can also be declared private. We'll see this
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`10.1.1 Compilation Units - Library Units <10-1-1>`
+    - :arm22:`10.1.1 Compilation Units - Library Units <10-1-1>`
 
 
 .. _Adv_Ada_Private_With_Clauses:
@@ -711,7 +711,7 @@ of a non-private child package.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`10.1.2 Context Clauses - With Clauses <10-1-2>`
+    - :arm22:`10.1.2 Context Clauses - With Clauses <10-1-2>`
 
 
 Limited Visibility
@@ -835,7 +835,7 @@ Now, both packages :ada:`A` and :ada:`B` have limited visibility to each other.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`10.1.2 Context Clauses - With Clauses <10-1-2>`
+    - :arm22:`10.1.2 Context Clauses - With Clauses <10-1-2>`
 
 Limited visibility and private with clauses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1352,7 +1352,7 @@ introduce two specific forms of use clauses: :ada:`use type` and
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`8.4 Use Clauses <8-4>`
+    - :arm22:`8.4 Use Clauses <8-4>`
 
 Another use clause example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1483,7 +1483,7 @@ they're not directly visible anymore, even if we have a use clause.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`8.4 Use Clauses <8-4>`
+    - :arm22:`8.4 Use Clauses <8-4>`
 
 Code example
 ~~~~~~~~~~~~

--- a/content/courses/advanced-ada/parts/modular_prog/packages.rst
+++ b/content/courses/advanced-ada/parts/modular_prog/packages.rst
@@ -3,22 +3,6 @@ Packages
 
 .. include:: ../../../global.txt
 
-.. _Adv_Ada_Pure:
-
-Pure program and library units
-------------------------------
-
-.. admonition:: Relevant topics
-
-    - :arm:`C.4 Preelaboration Requirements <C-4>`
-    - :arm:`10.2.1 Elaboration Control <10-2-1>`
-    - Add link to :ref:`Adv_Ada_Preelaboration` section
-
-.. todo::
-
-    Complete section!
-
-
 .. _Adv_Ada_Package_Renaming:
 
 Package renaming

--- a/content/courses/advanced-ada/parts/modular_prog/subprograms_modularity.rst
+++ b/content/courses/advanced-ada/parts/modular_prog/subprograms_modularity.rst
@@ -41,8 +41,8 @@ this procedure cannot be referenced in the :ada:`Show_Test` procedure.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`10.1.1 Compilation Units - Library Units <10-1-1>`
-    - :arm:`10.1.2 Context Clauses - With Clauses <10-1-2>`
+    - :arm22:`10.1.1 Compilation Units - Library Units <10-1-1>`
+    - :arm22:`10.1.2 Context Clauses - With Clauses <10-1-2>`
 
 
 Private subprograms of a package

--- a/content/courses/advanced-ada/parts/multithreading/tasking.rst
+++ b/content/courses/advanced-ada/parts/multithreading/tasking.rst
@@ -51,10 +51,10 @@ Task IDs and attributes
 
 .. admonition:: Relevant topics
 
-    - :arm:`Task and Entry Attributes <9-9>`
-    - :arm:`The Package Task_Identification <C-7-1>`
-    - :arm:`The Package Task_Attributes <C-7-2>`
-    - :arm:`The Package Task_Termination <C-7-3>`
+    - :arm22:`Task and Entry Attributes <9-9>`
+    - :arm22:`The Package Task_Identification <C-7-1>`
+    - :arm22:`The Package Task_Attributes <C-7-2>`
+    - :arm22:`The Package Task_Termination <C-7-3>`
 
 .. todo::
 
@@ -83,7 +83,7 @@ Task and synchronized interfaces
 .. admonition:: Relevant topics
 
     - :ada:`synchronized interface` and :ada:`task interface`, as mentioned in
-      :arm:`Interface Types <3-9-4>`
+      :arm22:`Interface Types <3-9-4>`
 
 .. todo::
 
@@ -95,7 +95,7 @@ Protected Subprograms and Protected Actions
 
 .. admonition:: Relevant topics
 
-    - :arm:`Protected Subprograms and Protected Actions <9-5-1>`
+    - :arm22:`Protected Subprograms and Protected Actions <9-5-1>`
 
 .. todo::
 
@@ -111,13 +111,13 @@ Protected Subprograms and Protected Actions
     .. admonition:: Relevant topics
 
         - **Briefly** discuss :ada:`CPU` aspect, as mentioned in
-        :arm:`Pragma CPU <J-15-9>`
+        :arm22:`Pragma CPU <J-15-9>`
         - **Briefly** discuss :ada:`Dispatching_Domain`, as mentioned in
-        :arm:`Pragma Dispatching_Domain <J-15-10>`
+        :arm22:`Pragma Dispatching_Domain <J-15-10>`
         - **Briefly** discuss priorities, as mentioned in
-        :arm:`Pragmas Priority and Interrupt_Priority <J-15-11>`
+        :arm22:`Pragmas Priority and Interrupt_Priority <J-15-11>`
         - **Briefly** discuss relative deadlines, as mentioned in
-        :arm:`Pragma Relative_Deadline <J-15-12>`
+        :arm22:`Pragma Relative_Deadline <J-15-12>`
 
 
 ..
@@ -129,7 +129,7 @@ Protected Subprograms and Protected Actions
     .. admonition:: Relevant topics
 
         - **Briefly** discuss policies, as mentioned in
-        :arm:`Conflict Check Policies <9-10-1>`
+        :arm22:`Conflict Check Policies <9-10-1>`
 
 
 ..
@@ -141,7 +141,7 @@ Protected Subprograms and Protected Actions
     .. admonition:: Relevant topics
 
         - **Briefly** discuss interrupts
-        - :arm:`Interrupt Support <C-3>`
-        - :arm:`Protected Procedure Handlers <C-3-1>`
-        - :arm:`The Package Interrupts <C-3-2>`
-        - :arm:`Interrupt Entries <J-7-1>`
+        - :arm22:`Interrupt Support <C-3>`
+        - :arm22:`Protected Procedure Handlers <C-3-1>`
+        - :arm22:`The Package Interrupts <C-3-2>`
+        - :arm22:`Interrupt Entries <J-7-1>`

--- a/content/courses/advanced-ada/parts/resource_management/access_types.rst
+++ b/content/courses/advanced-ada/parts/resource_management/access_types.rst
@@ -67,7 +67,7 @@ then assign an array aggregate to it |mdash| this becomes
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.1 Names <4-1>`
+    - :arm22:`4.1 Names <4-1>`
 
 
 .. _Adv_Ada_Implicit_Dereferencing:
@@ -349,11 +349,11 @@ supported:
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.1 Names <4-1>`
-    - :arm:`4.1.1 Indexed Components <4-1-1>`
-    - :arm:`4.1.2 Slices <4-1-2>`
-    - :arm:`4.1.3 Selected Components <4-1-3>`
-    - :arm:`4.1.4 Attributes <4-1-4>`
+    - :arm22:`4.1 Names <4-1>`
+    - :arm22:`4.1.1 Indexed Components <4-1-1>`
+    - :arm22:`4.1.2 Slices <4-1-2>`
+    - :arm22:`4.1.3 Selected Components <4-1-3>`
+    - :arm22:`4.1.4 Attributes <4-1-4>`
 
 
 .. _Adv_Ada_Ragged_Arrays:
@@ -663,7 +663,7 @@ words, :ada:`A1` or :ada:`A2` allow us to access the same object in memory.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10 Access Types <3-10>`
+    - :arm22:`3.10 Access Types <3-10>`
 
 
 .. _Adv_Ada_Aliased_Objects:
@@ -735,8 +735,8 @@ In the next sections, we discuss these features in more details.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.3.1 Object Declarations <3-3-1>`
-    - :arm:`3.10 Access Types <3-10>`
+    - :arm22:`3.3.1 Object Declarations <3-3-1>`
+    - :arm22:`3.10 Access Types <3-10>`
 
 General access modifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -854,7 +854,7 @@ write :ada:`I_Var := 22;`, but we cannot write :ada:`I_Var_C_Ptr.all := 22;`.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10.2 Operations of Access Types <3-10-2>`
+    - :arm22:`3.10.2 Operations of Access Types <3-10-2>`
 
 
 Non-aliased objects
@@ -1011,7 +1011,7 @@ address we're specifying (instead of assigning registers for those components).
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.6 Array Types <3-6>`
+    - :arm22:`3.6 Array Types <3-6>`
 
 
 Aliased parameters
@@ -1117,9 +1117,9 @@ it as :ada:`aliased Integer`, it is passed by reference.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.1 Subprogram Declarations <6-1>`
-    - :arm:`6.2 Formal Parameter Modes <6-2>`
-    - :arm:`6.4.1 Parameter Associations <6-4-1>`
+    - :arm22:`6.1 Subprogram Declarations <6-1>`
+    - :arm22:`6.2 Formal Parameter Modes <6-2>`
+    - :arm22:`6.4.1 Parameter Associations <6-4-1>`
 
 
 .. _Adv_Ada_Anonymous_Access_Types:
@@ -1188,7 +1188,7 @@ type, as we did in previous code examples.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10 Access Types <3-10>`
+    - :arm22:`3.10 Access Types <3-10>`
 
 
 Relation to named types
@@ -1374,7 +1374,7 @@ Anonymous Access-To-Object Types
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10 Access Types <3-10>`
+    - :arm22:`3.10 Access Types <3-10>`
 
 .. todo::
 
@@ -1559,7 +1559,7 @@ However, we could use other forms |mdash| such as :ada:`not null access`
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.1.5 User-Defined References <4-1-5>`
+    - :arm22:`4.1.5 User-Defined References <4-1-5>`
 
 Dereferencing of tagged types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1975,7 +1975,7 @@ type) and display its information by calling the :ada:`Show` procedure.
 
     .. admonition:: In the Ada Reference Manual
 
-        - :arm:`A.18.2 The Generic Package Containers.Vectors <A-18-2>`
+        - :arm22:`A.18.2 The Generic Package Containers.Vectors <A-18-2>`
 
 
 .. _Adv_Ada_Accessibility_Levels_Intro:
@@ -1993,7 +1993,7 @@ and build intuition on how to best use access types in your code.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10.2 Operations of Access Types <3-10-2>`
+    - :arm22:`3.10.2 Operations of Access Types <3-10-2>`
 
 Lifetime of objects
 ~~~~~~~~~~~~~~~~~~~
@@ -2835,7 +2835,7 @@ encapsulating access types in well-designed abstract data types.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`Unchecked Access Value Creation <13-10>`
+    - :arm22:`Unchecked Access Value Creation <13-10>`
 
 Unchecked Deallocation
 ----------------------
@@ -3011,8 +3011,8 @@ third calls to :ada:`Free` don't have any effect.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`4.8 Allocators <4-8>`
-    - :arm:`13.11.2 Unchecked Storage Deallocation <13-11-2>`
+    - :arm22:`4.8 Allocators <4-8>`
+    - :arm22:`13.11.2 Unchecked Storage Deallocation <13-11-2>`
 
 
 .. _Adv_Ada_Unchecked_Deallocation_Dangling_References:
@@ -3216,8 +3216,8 @@ unchecked deallocation: avoid creating dangling references!
 
 .. admonition:: In the Ada Reference Manual
 
-   - :arm:`13.9.1 Data Validity <13-9-1>`
-   - :arm:`13.11.2 Unchecked Storage Deallocation <13-11-2>`
+   - :arm22:`13.9.1 Data Validity <13-9-1>`
+   - :arm22:`13.11.2 Unchecked Storage Deallocation <13-11-2>`
 
 
 Restrictions for :ada:`Ada.Unchecked_Deallocation`
@@ -3668,7 +3668,7 @@ Here, we get access to the :ada:`Add_Ten` procedure and pass it to the
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.10 Access Types <3-10>`
+    - :arm22:`3.10 Access Types <3-10>`
 
 
 Selecting subprograms

--- a/content/courses/advanced-ada/parts/resource_management/containers.rst
+++ b/content/courses/advanced-ada/parts/resource_management/containers.rst
@@ -22,8 +22,8 @@ User-Defined Iterator Types
 
 .. admonition:: Relevant topics
 
-    - :arm:`User-Defined Iterator Types <5-5-1>`
-    - :arm:`Generalized Loop Iteration <5-5-2>`
+    - :arm22:`User-Defined Iterator Types <5-5-1>`
+    - :arm22:`Generalized Loop Iteration <5-5-2>`
     - :arm22:`Procedural Iterators <5-5-3>`
 
 .. todo::

--- a/content/courses/advanced-ada/parts/resource_management/limited_types.rst
+++ b/content/courses/advanced-ada/parts/resource_management/limited_types.rst
@@ -167,7 +167,7 @@ information is copied to multiple objects of the same type.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`7.5 Limited Types <7-5>`
+    - :arm22:`7.5 Limited Types <7-5>`
 
 
 Assignments
@@ -471,7 +471,7 @@ and full views can have non-matching declarations.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`7.5 Limited Types <7-5>`
+    - :arm22:`7.5 Limited Types <7-5>`
 
 
 Partial and full view of limited types
@@ -697,8 +697,8 @@ tagged types. We discuss this topic in another chapter.)
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`7.3 Private Types and Private Extensions <7-3>`
-    - :arm:`7.5 Limited Types <7-5>`
+    - :arm22:`7.3 Private Types and Private Extensions <7-3>`
+    - :arm22:`7.5 Limited Types <7-5>`
 
 
 Deriving from limited private types
@@ -1026,7 +1026,7 @@ Here, the compiler indicates that the assignment is forbidden because the
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`3.8 Record Types <3-8>`
+    - :arm22:`3.8 Record Types <3-8>`
 
 
 Limited types and aggregates
@@ -2147,7 +2147,7 @@ by copy is made by the compiler.
 
 .. admonition:: In the Ada Reference Manual
 
-    - :arm:`6.2 Formal Parameter Modes <6-2>`
-    - :arm:`6.4.1 Parameter Associations <6-4-1>`
-    - :arm:`7.5 Limited Types <7-5>`
+    - :arm22:`6.2 Formal Parameter Modes <6-2>`
+    - :arm22:`6.4.1 Parameter Associations <6-4-1>`
+    - :arm22:`7.5 Limited Types <7-5>`
 

--- a/content/courses/advanced-ada/parts/resource_management/memory_management.rst
+++ b/content/courses/advanced-ada/parts/resource_management/memory_management.rst
@@ -13,7 +13,7 @@ Size Information
     - :ada:`'Max_Size_In_Storage_Elements`
     - :ada:`System.Storage_Elements` package
     - :ada:`System.Storage_Elements.Storage_Element'Size`
-        - :arm:`The Package System.Storage_Elements <13-7-1>`
+        - :arm22:`The Package System.Storage_Elements <13-7-1>`
 
 .. todo::
 
@@ -25,7 +25,7 @@ Address vs. access
 
 .. admonition:: Relevant topics
 
-    - :arm:`The Package System.Address_To_Access_Conversions <13-7-2>`
+    - :arm22:`The Package System.Address_To_Access_Conversions <13-7-2>`
 
 .. todo::
 
@@ -37,8 +37,8 @@ Finalization
 
 .. admonition:: Relevant topics
 
-    - :arm:`Assignment and Finalization <7-6>`
-    - :arm:`Completion and Finalization <7-6-1>`
+    - :arm22:`Assignment and Finalization <7-6>`
+    - :arm22:`Completion and Finalization <7-6-1>`
 
 .. todo::
 
@@ -51,10 +51,10 @@ Memory pools
 
 .. admonition:: Relevant topics
 
-    - :arm:`Memory pools <13-11>`
-    - :arm:`Default Storage Pools <13-11-3>`
-    - :arm:`Storage subpools <13-11-4>`
-    - :arm:`Subpool Reclamation <13-11-5>`
+    - :arm22:`Memory pools <13-11>`
+    - :arm22:`Default Storage Pools <13-11-3>`
+    - :arm22:`Storage subpools <13-11-4>`
+    - :arm22:`Subpool Reclamation <13-11-5>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/resource_management/restrictions.rst
+++ b/content/courses/advanced-ada/parts/resource_management/restrictions.rst
@@ -8,8 +8,8 @@ Pragmas
 
 .. admonition:: Relevant topics
 
-    - :arm:`Pragma Restrictions and Pragma Profile <13-12>`
-    - :arm:`Dependence Restriction Identifiers <J-13>`
+    - :arm22:`Pragma Restrictions and Pragma Profile <13-12>`
+    - :arm22:`Dependence Restriction Identifiers <J-13>`
 
 .. todo::
 
@@ -21,7 +21,7 @@ Language-Defined Restrictions and Profiles
 
 .. admonition:: Relevant topics
 
-    - :arm:`Language-Defined Restrictions and Profiles <13-12-1>`
+    - :arm22:`Language-Defined Restrictions and Profiles <13-12-1>`
 
 .. todo::
 

--- a/content/courses/advanced-ada/parts/resource_management/standard_containers.rst
+++ b/content/courses/advanced-ada/parts/resource_management/standard_containers.rst
@@ -8,7 +8,7 @@ Linked lists
 
 .. admonition:: Relevant topics
 
-    - :arm:`Containers.Doubly_Linked_Lists <A-18-3>`
+    - :arm22:`Containers.Doubly_Linked_Lists <A-18-3>`
 
 .. todo::
 
@@ -19,7 +19,7 @@ Trees
 
 .. admonition:: Relevant topics
 
-    - :arm:`Containers.Multiway_Trees <A-18-25>`
+    - :arm22:`Containers.Multiway_Trees <A-18-25>`
 
 .. todo::
 
@@ -30,11 +30,11 @@ Queue containers
 
 .. admonition:: Relevant topics
 
-    - :arm:`Containers.Synchronized_Queue_Interfaces <A-18-27>`
-    - :arm:`Containers.Unbounded_Synchronized_Queues <A-18-28>`
-    - :arm:`Containers.Bounded_Synchronized_Queues <A-18-29>`
-    - :arm:`Containers.Unbounded_Priority_Queues <A-18-30>`
-    - :arm:`Containers.Bounded_Priority_Queues <A-18-31>`
+    - :arm22:`Containers.Synchronized_Queue_Interfaces <A-18-27>`
+    - :arm22:`Containers.Unbounded_Synchronized_Queues <A-18-28>`
+    - :arm22:`Containers.Bounded_Synchronized_Queues <A-18-29>`
+    - :arm22:`Containers.Unbounded_Priority_Queues <A-18-30>`
+    - :arm22:`Containers.Bounded_Priority_Queues <A-18-31>`
 
 .. todo::
 
@@ -58,7 +58,7 @@ Holder container
 
 .. admonition:: Relevant topics
 
-    - :arm:`Containers.Indefinite_Holders <A-18-18>`
+    - :arm22:`Containers.Indefinite_Holders <A-18-18>`
 
 .. todo::
 

--- a/content/courses/intro-to-ada/chapters/privacy.rst
+++ b/content/courses/intro-to-ada/chapters/privacy.rst
@@ -1,3 +1,5 @@
+.. _Intro_Ada_Course_Privacy:
+
 Privacy
 =======
 

--- a/content/courses/intro-to-ada/index.rst
+++ b/content/courses/intro-to-ada/index.rst
@@ -6,6 +6,8 @@
 :prev_state: False
 :next_state: False
 
+.. _Intro_Ada_Course_Index:
+
 Introduction to Ada
 ===================
 

--- a/content/courses/intro-to-embedded-sys-prog/chapters/low_level_programming.rst
+++ b/content/courses/intro-to-embedded-sys-prog/chapters/low_level_programming.rst
@@ -1,3 +1,5 @@
+.. _Intro_Embedded_Sys_Prog_Low_Level_Programming:
+
 Low Level Programming
 =====================
 

--- a/content/courses/intro-to-embedded-sys-prog/index.rst
+++ b/content/courses/intro-to-embedded-sys-prog/index.rst
@@ -1,6 +1,8 @@
 :prev_state: False
 :next_state: False
 
+.. _Intro_Embedded_Sys_Prog_Index:
+
 Introduction to Embedded Systems Programming
 ============================================
 

--- a/content/hidden.txt
+++ b/content/hidden.txt
@@ -1,2 +1,1 @@
-courses/advanced-ada
 courses/advanced-spark

--- a/content/index.rst
+++ b/content/index.rst
@@ -69,6 +69,7 @@
         :caption: Courses
 
         Introduction to Ada <courses/intro-to-ada/index>
+        Advanced Journey With Ada <courses/advanced-ada/index>
         Introduction to SPARK <courses/intro-to-spark/index>
         Introduction to Embedded Systems Programming <courses/intro-to-embedded-sys-prog/index>
         What's New in Ada 2022 <courses/whats-new-in-ada-2022/index>
@@ -83,7 +84,6 @@
             :maxdepth: 1
             :caption: Upcoming Courses
 
-            Advanced Journey With Ada <courses/advanced-ada/index>
             Advanced SPARK <courses/advanced-spark/index>
 
     .. toctree::
@@ -176,6 +176,25 @@
 
             .. container:: frontpage-ebook-and-buttons-block
 
+                .. image:: images/page-1-of-advanced-ada-temp.jpeg
+                    :alt: Advanced Journey With Ada: A Flight In Progress (e-book)
+                    :width: 149pt
+
+                .. raw:: html
+
+                        <div class="frontpage-ebook-download">
+                            <a class="ebook-download-button" href="/pdf_books/courses/advanced-ada.pdf">
+                                PDF
+                            </a>
+
+                            <a class="ebook-download-button" href="/epub_books/courses/advanced-ada.epub">
+                                EPUB
+                            </a>
+                        </div>
+
+
+            .. container:: frontpage-ebook-and-buttons-block
+
                 .. image:: images/page-1-of-intro-to-spark.jpeg
                     :alt: Introduction to SPARK (e-book)
                     :width: 149pt
@@ -192,6 +211,8 @@
                             </a>
                         </div>
 
+
+        .. container:: frontpage-ebooks-row
 
             .. container:: frontpage-ebook-and-buttons-block
 
@@ -212,8 +233,6 @@
                         </div>
 
 
-        .. container:: frontpage-ebooks-row
-
             .. container:: frontpage-ebook-and-buttons-block
 
                 .. image:: images/page-1-of-whats-new-in-ada-2022.jpeg
@@ -232,6 +251,8 @@
                             </a>
                         </div>
 
+
+        .. container:: frontpage-ebooks-row
 
             .. container:: frontpage-ebook-and-buttons-block
 
@@ -252,8 +273,6 @@
                         </div>
 
 
-        .. container:: frontpage-ebooks-row
-
             .. container:: frontpage-ebook-and-buttons-block
 
                 .. image:: images/page-1-of-Ada_For_The_Embedded_C_Developer.jpeg
@@ -273,6 +292,8 @@
                         </div>
 
 
+        .. container:: frontpage-ebooks-row
+
             .. container:: frontpage-ebook-and-buttons-block
 
                 .. image:: images/page-1-of-SPARK_for_the_MISRA_C_Developer.jpeg
@@ -291,8 +312,6 @@
                             </a>
                         </div>
 
-
-        .. container:: frontpage-ebooks-row
 
             .. container:: frontpage-ebook-and-buttons-block
 
@@ -325,25 +344,6 @@
     .. container:: frontpage-ebooks
 
         .. container:: frontpage-ebooks-row
-
-            .. container:: frontpage-ebook-and-buttons-block
-
-                .. image:: images/page-1-of-advanced-ada-temp.jpeg
-                    :alt: Advanced Journey With Ada: A Flight In Progress (e-book)
-                    :width: 149pt
-
-                .. raw:: html
-
-                        <div class="frontpage-ebook-download">
-                            <a class="ebook-download-button" href="/pdf_books/courses/advanced-ada.pdf">
-                                PDF
-                            </a>
-
-                            <a class="ebook-download-button" href="/epub_books/courses/advanced-ada.epub">
-                                EPUB
-                            </a>
-                        </div>
-
 
             .. container:: frontpage-ebook-and-buttons-block
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -165,7 +165,8 @@ endif
 	@$(TEST_DRIVER) $(TEST_OPTIONS_EXT) $(CONTENT_DIR)/training_examples/fundamentals_of_ada/*.rst
 	@echo ""
 
-test_content: test_ada_intro test_spark_intro test_intro_to_embedded_sys_prog \
+test_content: test_ada_intro test_advanced_ada \
+	test_spark_intro test_intro_to_embedded_sys_prog \
 	test_whats_new_in_ada_2022 \
 	test_spark_for_the_misra_c_developer \
 	test_ada_for_the_cpp_java_developer \
@@ -177,7 +178,7 @@ test_content: test_ada_intro test_spark_intro test_intro_to_embedded_sys_prog \
 	@mkdir -p $(BUILDDIR)/zip
 	@mv $(SRC_TEST_DIR)/$(COMPLETE_SITE_BOOK)_code.zip $(BUILDDIR)/zip
 
-test_hidden_content: test_advanced_ada test_advanced_spark \
+test_hidden_content: test_advanced_spark \
 	test_training_fundamentals
 	@echo ""
 


### PR DESCRIPTION
- Referring to ARM 2022 everywhere.
- Correcting some dates and titles.
- Correcting some cross-references.
- Removed Advanced Ada from list of hidden courses.