### PR TITLE
Widget: fixing overlap issue for dropout menu

### DIFF
--- a/frontend/src/styles/learn.scss
+++ b/frontend/src/styles/learn.scss
@@ -217,7 +217,7 @@ pre.widget {
             background-color: $color-theme-bg-light;
             min-width: 300px;
             box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-            z-index: 1;
+            z-index: 10;
             padding: 8px;
             cursor: pointer;
             -webkit-user-select: none;


### PR DESCRIPTION
This issue caused the dropout menu to be hidden behind the surrounding text.