### PR TITLE
Fix backend error being shown by mistake, which was hiding actual result

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,7 +111,9 @@
       "plugin:@typescript-eslint/recommended",
       "google"
     ],
-    "rules": {},
+    "rules": {
+      "max-len": ["error", {"ignoreRegExpLiterals": true}]
+    },
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"


### PR DESCRIPTION
When the frontend receives a responses from the backend, it tries to find the file which relates to the message. If it finds a file it then decorate the line with the message, rather than just printing the message to the homeArea as normal.

But there are cases where the file name/line number is found, but the file is not available in the view (e.g. #937), which was causing a backend error message to be erroneously displayed. Now in cases where it doesn't find the file it just prints the message to the homeArea.

This change also simplifies the logic for performing this highlighting, and increases the number of cases it's able to highlight. For example, cases like
```
raised INTERNAL_EXCEPTIONS.INT_E : show_exception_renaming_view.adb:8
raised CONSTRAINT_ERROR : show_exception_renaming.adb:4
```
were not previously highlighted, but now are.

Fixes  #937