### PR TITLE
Fix Java example code

### DIFF
--- a/content/courses/Ada_For_The_CPP_Java_Developer/chapters/08_Classes_and_Object_Oriented_Programming.rst
+++ b/content/courses/Ada_For_The_CPP_Java_Developer/chapters/08_Classes_and_Object_Oriented_Programming.rst
@@ -432,11 +432,11 @@ Ada doesn't offer multiple inheritance the way C++ does, but it does support a J
    }
 
    public interface I1 {
-      public void M2 () = 0;
+      public void M2 ();
    }
 
-   public class I2 {
-      public void M3 () = 0;
+   public interface I2 {
+      public void M3 ();
    }
 
    public class Child extends Root implements I1, I2 {


### PR DESCRIPTION
In the Java code block, `I2` should be an interface instead of a class (because `Child` _implements_ `I2`) and the methods `M2` and `M3` should use Java syntax instead of C++ syntax.