### PR TITLE
Frontend: avoid jsdoc warnings about undefined types

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,6 +115,7 @@
       "plugin:@typescript-eslint/recommended"
     ],
     "rules": {
+      "jsdoc/no-undefined-types": "off",
       "max-len": [
         "error",
         {


### PR DESCRIPTION
Warnings are false positives, as those types indicated in the warnings should be known by the compiler.