### PR TITLE
Small updates.

### DIFF
--- a/content/courses/ada-idioms/chapters/abstract_data_types.rst
+++ b/content/courses/ada-idioms/chapters/abstract_data_types.rst
@@ -8,8 +8,8 @@ Abstract Data Types
 Motivation
 ----------
 
-In the previous idiom (the
-:ref:`Groups of Related Program Units <Ada_Idioms_Groups_Of_Related_Program_Units>`),
+In the 
+:ref:`Groups of Related Program Units <Ada_Idioms_Groups_Of_Related_Program_Units>` idiom,
 client compile-time visibility to the type's representation is both an
 advantage and a disadvantage. Visibility to the representation makes available
 the expressiveness of low-level syntax, such as array indexing and aggregates,

--- a/content/courses/ada-idioms/chapters/component_access_to_rec_objs.rst
+++ b/content/courses/ada-idioms/chapters/component_access_to_rec_objs.rst
@@ -563,12 +563,6 @@ record component types. We could use the Hardware Abstraction Layer
 affect the idiom expression itself.
 
 
-Bibliography
------------------
-
-None.
-
-
 .. _Ada_Idioms_Serial_IO_Complete_Example:
 
 


### PR DESCRIPTION
component_access_to_rec_objs.rst : Remove empty ("None.") Bibliography section.

abstract_data_types.rst : Remove reference to "previous entry" since no longer all in one section.