### PR TITLE
Vagrant VM: use old-releases repo for Ubuntu installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,10 @@
 $frontend = <<-SHELL
   #!/bin/bash -eux
 
+  # TEMPORARY: Path old Ubuntu release
+  sed -i -e 's#archive.ubuntu.com#old-releases.ubuntu.com#' /etc/apt/sources.list
+  sed -i -e 's#security.ubuntu.com#old-releases.ubuntu.com#' /etc/apt/sources.list
+
   # Enable the NodeSource repository
   curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
@@ -86,6 +90,10 @@ SHELL
 
 $epub = <<-SHELL
   #!/bin/bash -eux
+
+  # TEMPORARY: Path old Ubuntu release
+  sed -i -e 's#archive.ubuntu.com#old-releases.ubuntu.com#'  /etc/apt/sources.list
+  sed -i -e 's#security.ubuntu.com#old-releases.ubuntu.com#' /etc/apt/sources.list
 
   # Enable the NodeSource repository
   curl -sL https://deb.nodesource.com/setup_20.x | bash -


### PR DESCRIPTION
Replace archive.ubuntu.com and security.ubuntu.com by old-releases.ubuntu.com for Ubuntu 23.10 installation.