### PR TITLE
Drop `Default_Switches` from project files.

### DIFF
--- a/frontend/src/ts/download.ts
+++ b/frontend/src/ts/download.ts
@@ -23,12 +23,10 @@ const MAIN_GPR = `project Main is
    --LANGUAGE_PLACEHOLDER--
 
    package Compiler is
-      for Default_Switches ("Ada") use ("-g", "-O0");
       --COMPILER_SWITCHES_PLACEHOLDER--
    end Compiler;
 
    package Builder is
-      for Default_Switches ("Ada") use ("-g");
       --BUILDER_SWITCHES_PLACEHOLDER--
       for Global_Configuration_Pragmas use "main.adc";
    end Builder;
@@ -42,12 +40,10 @@ const SPARK_GPR = `project Main_Spark is
    --LANGUAGE_PLACEHOLDER--
 
    package Compiler is
-      for Default_Switches ("Ada") use ("-g", "-O0");
       --COMPILER_SWITCHES_PLACEHOLDER--
    end Compiler;
 
    package Builder is
-      for Default_Switches ("Ada") use ("-g");
       --BUILDER_SWITCHES_PLACEHOLDER--
       for Global_Configuration_Pragmas use "main_spark.adc";
    end Builder;


### PR DESCRIPTION
`gprbuild` ignores `Default_Switches` when there is `Switches` clause. Gprbuild guide says:

> Value is a list of switches to be used when invoking the compiler
> for the language for a source of the project,
> if **there is no applicable attribute** Switches.

On the other side `Default_Switches` confuseis GNAT Studio.

Fix #1166