### PR TITLE
Fix for null access support in example

### DIFF
--- a/content/courses/advanced-ada/parts/resource_management/access_types.rst
+++ b/content/courses/advanced-ada/parts/resource_management/access_types.rst
@@ -4178,13 +4178,13 @@ Let's see an example:
          (if Obj /= null then Obj.all else "");
 
        function Copy (Obj : Info) return Info is
-         (To_Info (Obj.all));
+         (To_Info (To_String (Obj)));
 
        procedure Copy (To   : in out Info;
                        From :        Info) is
        begin
           Destroy (To);
-          To := To_Info (From.all);
+          To := Copy (From);
        end Copy;
 
        procedure Append (Obj : in out Info;


### PR DESCRIPTION
Fixes null access exceptions for example in advanced Ada / Resource Management / Access Types / Access Type Abstraction example when calling `Copy` (both versions) with a `Info = null`