### PR TITLE
CI: split LEARN_LATEST_TOKEN into separate read/write tokens

### DIFF
--- a/.github/workflows/publish-learn-latest.yml
+++ b/.github/workflows/publish-learn-latest.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
     - name: Trigger publishing on learn-latest repo
       env:
-        TOKEN: ${{ secrets.LEARN_LATEST_TOKEN }}
+        LEARN_REPO_TOKEN: ${{ secrets.LEARN_READ_TOKEN }}
+        LEARN_LATEST_REPO_TOKEN: ${{ secrets.LEARN_LATEST_WRITE_TOKEN }}
         HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         BOOKS_RUN_ID: ${{ github.event.workflow_run.id }}
         SOURCE_REPO: ${{ github.repository }}
@@ -31,17 +32,20 @@ jobs:
         service="publish-learn-latest"
 
         # Look up the successful Sphinx Content Tests run ID for the same commit
+        # (read-only access to AdaCore/learn)
         content_run_id=$(curl -L --fail-with-body \
-          -H "Authorization: Bearer $TOKEN" \
+          -H "Authorization: Bearer $LEARN_REPO_TOKEN" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/repos/$SOURCE_REPO/actions/workflows/sphinx-content-tests.js.yml/runs?head_sha=$HEAD_SHA&status=success&per_page=1" \
           | jq -r '.workflow_runs[0].id')
 
+        # Trigger the publish workflow on AdaCore/learn-latest-html-pages
+        # (write access to AdaCore/learn-latest-html-pages)
         curl -L --fail-with-body \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $TOKEN" \
+          -H "Authorization: Bearer $LEARN_LATEST_REPO_TOKEN" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
           -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$HEAD_SHA\", \"books_run_id\": \"$BOOKS_RUN_ID\", \"content_run_id\": \"$content_run_id\", \"source_repo\": \"$SOURCE_REPO\", \"unit\": false, \"integration\": true}}"


### PR DESCRIPTION
Use LEARN_READ_TOKEN (read-only for AdaCore/learn) to look up workflow run IDs, and LEARN_LATEST_WRITE_TOKEN (write for AdaCore/learn-latest-html-pages) to trigger the repository_dispatch event.