### PR TITLE
Editorial: fix identifier typos and factual errors across course materials

### DIFF
--- a/content/booklets/adacore-technologies-for-railway-software/chapters/technology.rst
+++ b/content/booklets/adacore-technologies-for-railway-software/chapters/technology.rst
@@ -350,8 +350,8 @@ according to their dimension. The system is implemented based on the
 seven base dimensions (meter, kilogram, second, ampere, kelvin, mole,
 candela), and will check that operations between these types are
 consistent.
-For example, a type :ada:`Speed` can be defined to represent time per
-distance. Consistency between these types is checked at compile time
+For example, a type :ada:`Speed` can be defined to represent distance per
+time. Consistency between these types is checked at compile time
 so that dimension errors will be reported as errors. For example:
 
 .. code-block:: ada

--- a/content/courses/advanced-ada/parts/data_types/aggregates.rst
+++ b/content/courses/advanced-ada/parts/data_types/aggregates.rst
@@ -1787,7 +1787,7 @@ aggregates in assignments to this object:
 In the first assignment to :ada:`P_3D` in the example above, we're
 initializing this object with information from :ada:`P_2D` and specifying
 the value of the :ada:`Z` component. Then, in the next assignment to the
-:ada:`P_3D` object, we're using an aggregate with information from :ada:`P_1`
+:ada:`P_3D` object, we're using an aggregate with information from :ada:`P_1D`
 and specifying values for the :ada:`Y` and :ada:`Z` components. (Just as a
 reminder, we can write :ada:`Y | Z => 0.1` to assign 0.1 to both :ada:`Y` and
 :ada:`Z` components.)

--- a/content/courses/advanced-ada/parts/data_types/arrays.rst
+++ b/content/courses/advanced-ada/parts/data_types/arrays.rst
@@ -771,7 +771,7 @@ Let's use these subtypes in a test application:
 
 As expected, assignments to objects with different subtypes |mdash| but with
 the same parent type |mdash| work fine without conversion. The assignment to
-:ada:`M_Max_20` fails because of the predicate failure: the predicate requires
+:ada:`M_Max20` fails because of the predicate failure: the predicate requires
 that the length be 20 at most, and it's 40 in this case. Also, the
 assignment to :ada:`M_F2` fails because the predicate requires that the first
 element must be set to :ada:`2.0`, and :ada:`MD10 (1)` has the value 4.0.

--- a/content/courses/advanced-ada/parts/data_types/types.rst
+++ b/content/courses/advanced-ada/parts/data_types/types.rst
@@ -524,7 +524,7 @@ Let's see an example:
     end Show_Object_View;
 
 In this example, both :ada:`Default` and :ada:`Dev` are constant objects.
-However, they have different views: while :ada:`Default_S` has a constant view
+However, they have different views: while :ada:`Default` has a constant view
 because it doesn't have any parts with variable view, :ada:`Dev` has a variable
 view because it's a private type. Finally, as expected, :ada:`Settings` has a
 variable view because it's a variable object.

--- a/content/courses/advanced-ada/parts/resource_management/containers.rst
+++ b/content/courses/advanced-ada/parts/resource_management/containers.rst
@@ -204,7 +204,7 @@ Let's see a complete code example:
     end Show_Container_Aggregate_Empty;
 
 In this example, we specify the :ada:`Empty` function for the :ada:`Aggregate`
-aspect of the container type :ada:`T`. (We also use the :ada:`Add_Unnamed`
+aspect of the container type :ada:`T`. (We also use the :ada:`Add_Named`
 element. You can ignore it for the moment: we'll discuss it later on.)
 
 The :ada:`A := []` statement in the :ada:`Show_Container_Aggregate_Empty`

--- a/content/courses/intro-to-embedded-sys-prog/chapters/multi_language_development.rst
+++ b/content/courses/intro-to-embedded-sys-prog/chapters/multi_language_development.rst
@@ -991,7 +991,7 @@ language standard.
 Package Interfaces.C.Strings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Package :ada:`Interfaces.C` declares types and subprograms allowing an Ada
+Package :ada:`Interfaces.C.Strings` declares types and subprograms allowing an Ada
 program to allocate, reference, update, and free C-style strings. In
 particular, the private type :ada:`chars_ptr` corresponds to a common use of
 :ada:`char *` in C programs, and an object of this type can be passed to


### PR DESCRIPTION
Corrects six editorial errors caught during proofreading — four identifier
typos, one conceptual inversion, and one incorrect package name.

## Changes

### AdaCore Technologies for Railway Software
- `technology.rst`: Fix inverted Speed type definition — was described as
  "time per distance"; corrected to "distance per time".

### Advanced Ada — Data Types
- `aggregates.rst`: Fix object name `P_1` → `P_1D` in prose referring to
  a 1D point aggregate example.
- `arrays.rst`: Fix subtype name `M_Max_20` → `M_Max20` to match the
  actual identifier declared in the code sample.
- `types.rst`: Fix object name `Default_S` → `Default` in explanation of
  constant vs. variable views.

### Advanced Ada — Resource Management
- `containers.rst`: Fix aspect procedure name `Add_Unnamed` → `Add_Named`
  in the container aggregate example walkthrough.

### Introduction to Embedded Systems Programming
- `multi_language_development.rst`: Fix package name `Interfaces.C` →
  `Interfaces.C.Strings` in the section introducing C string interop.

## Impact

Prose-only changes; no code, tests, or configuration affected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
