### PR TITLE
Vagrant: run pnpm install as vagrant user, not root

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,10 +76,9 @@ $frontend = <<-SHELL
   # Needed for npm
   echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
 
-  cd /vagrant/frontend
   echo 'export COREPACK_ENABLE_DOWNLOAD_PROMPT=0' >> /home/vagrant/.bashrc
   yes | corepack enable
-  pnpm install --frozen-lockfile
+  sudo -u vagrant bash -c "export COREPACK_ENABLE_DOWNLOAD_PROMPT=0; cd /vagrant/frontend && pnpm install --frozen-lockfile"
 
 SHELL
 
@@ -211,10 +210,9 @@ $epub = <<-SHELL
   # Needed for npm
   echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
 
-  cd /vagrant/frontend
   echo 'export COREPACK_ENABLE_DOWNLOAD_PROMPT=0' >> /home/vagrant/.bashrc
   yes | corepack enable
-  pnpm install --frozen-lockfile
+  sudo -u vagrant bash -c "export COREPACK_ENABLE_DOWNLOAD_PROMPT=0; cd /vagrant/frontend && pnpm install --frozen-lockfile"
 
 SHELL
 


### PR DESCRIPTION
Previously, both provisioning scripts ran `pnpm install --frozen-lockfile` as root (the default for Vagrant shell provisioners). This linked node_modules from root's pnpm store (/root/.local/share/pnpm/store/v11), causing an ERR_PNPM_UNEXPECTED_STORE mismatch whenever the vagrant user ran pnpm commands (which use /home/vagrant/.local/share/pnpm/store/v11).

Fixed by running pnpm install via `sudo -u vagrant bash -c "..."` so node_modules is linked from the vagrant user's store from the start. COREPACK_ENABLE_DOWNLOAD_PROMPT=0 is passed explicitly since .bashrc is not sourced in the non-interactive subshell.