### PR TITLE
Frontend: webpack build optimizations — contenthash and persistent cache

### DIFF
--- a/frontend/webpack.common.cjs
+++ b/frontend/webpack.common.cjs
@@ -75,7 +75,7 @@ const css_rule = function(env) {
 
 const font_rule = function(env) {
   const fontloader_opts = {
-    name: '[name].[ext]?[fullhash]',
+    name: '[name].[ext]?[contenthash]',
     outputPath: 'fonts/',
     publicPath: '/_static/fonts/'
   };
@@ -107,7 +107,7 @@ module.exports = function(env) {
   return {
     entry: './src/index.ts',
     output: {
-      filename: '[name].[fullhash].js',
+      filename: '[name].[contenthash].js',
       path: path.resolve(__dirname, 'dist', 'html', '_static')
     },
     resolve: {
@@ -135,7 +135,7 @@ module.exports = function(env) {
     plugins: [
       new CleanWebpackPlugin(),
       new MiniCssExtractPlugin({
-        filename: '[name].[fullhash].css',
+        filename: '[name].[contenthash].css',
       }),
       new Chunks2JsonPlugin(),
       new ESLintPlugin(myEslintOptions),

--- a/frontend/webpack.common.cjs
+++ b/frontend/webpack.common.cjs
@@ -120,6 +120,13 @@ module.exports = function(env) {
       }
     },
 
+    cache: {
+      type: 'filesystem',
+      buildDependencies: {
+        config: [__filename],
+      },
+    },
+
     module: {
       rules: [
         ts_rule(env),


### PR DESCRIPTION
## Summary

Two low-effort webpack 5 optimizations to the `frontend/webpack.common.cjs`
configuration:

- **contenthash:** replace `[fullhash]` with `[contenthash]` on all output
  filenames (JS, CSS, fonts). `[contenthash]` hashes only the content of each
  individual chunk, so unchanged chunks keep their filename across builds.
  `[fullhash]` rotated every filename on any change to any module.
- **Persistent filesystem cache:** enable webpack 5's built-in module-graph
  cache. Serializes resolved modules to `node_modules/.cache/webpack/` after a
  cold build; subsequent builds restore from cache, giving a significant warm-
  build speedup for local development and CI (when the cache directory is
  restored between runs).

## Changes

- `frontend/webpack.common.cjs`: `output.filename` and
  `MiniCssExtractPlugin.filename` changed from `[fullhash]` to `[contenthash]`
- `frontend/webpack.common.cjs`: `font_rule` name option changed from
  `[name].[ext]?[fullhash]` to `[name].[ext]?[contenthash]`
- `frontend/webpack.common.cjs`: `cache: { type: 'filesystem', ... }` block
  added

## Testing / Validation

Tested on web VM — Node.js 24, pnpm 11, webpack 5.107.2.

**contenthash independence:** edited one string literal in `dom-utils.ts`
(which is imported by the entry point). Only the `main.js` chunk hash changed
(`2277acdf…` → `02e595ad…`); the vendor split-chunk (`634.12d978….js`) and
the CSS chunk (`main.7c35a299….css`) kept their filenames unchanged. Reverting
the edit restored the original hash, confirming deterministic contenthash
behaviour.

**Persistent cache — warm-build speedup:**
- Cold build (empty cache): **27.7 s**
- Warm build (cache populated): **3.6 s** — 7.5× faster; output filenames
  identical to the cold build
- Config invalidation: a whitespace-only edit to `webpack.common.cjs` triggered
  a full rebuild (**19.8 s**), confirming that `buildDependencies.config` works
  as expected

## Notes

The `node_modules/.cache/webpack/` cache directory is already excluded from
git via the `node_modules` entry in `frontend/.gitignore`. For CI warm-build
benefit, this directory should be cached in the GitHub Actions workflow (see
the "Cache build artifacts across CI runs" proposal in
`LEARN_INFRASTRUCTURE_IMPROVEMENTS.md`).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>