### PR TITLE
Frontend: fix all ESLint findings and add CI enforcement

### DIFF
--- a/.github/workflows/eslint.js.yml
+++ b/.github/workflows/eslint.js.yml
@@ -1,0 +1,37 @@
+name: ESLint
+
+on:
+  push:
+    paths:
+      - 'frontend/**/*.ts'
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  eslint:
+
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        node-version: [24.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Enable Corepack
+      run: corepack enable
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+        cache-dependency-path: 'frontend/pnpm-lock.yaml'
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+    - name: Run ESLint
+      run: pnpm run eslint

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,6 +1,7 @@
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import jsdocPlugin from 'eslint-plugin-jsdoc';
+import chaiFriendlyPlugin from 'eslint-plugin-chai-friendly';
 
 export default [
   {
@@ -28,6 +29,17 @@ export default [
       ...tsPlugin.configs.recommended.rules,
       'jsdoc/no-undefined-types': 'off',
       'max-len': ['error', {ignoreRegExpLiterals: true}],
+    },
+  },
+  {
+    // chai-friendly's rule recognizes chai assertions as non-dead expressions.
+    files: ['tests/**/*.ts'],
+    plugins: {
+      'chai-friendly': chaiFriendlyPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-expressions': 'off',
+      'chai-friendly/no-unused-expressions': 'error',
     },
   },
 ];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,6 +29,7 @@ export default [
       ...tsPlugin.configs.recommended.rules,
       'jsdoc/no-undefined-types': 'off',
       'max-len': ['error', {ignoreRegExpLiterals: true}],
+      '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
     },
   },
   {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,7 +3,14 @@ import tsParser from '@typescript-eslint/parser';
 import jsdocPlugin from 'eslint-plugin-jsdoc';
 
 export default [
-  jsdocPlugin.configs['flat/recommended'],
+  {
+    // tests/html/ is regenerated Sphinx build output (gitignored), not project code.
+    ignores: ['tests/html/**'],
+  },
+  {
+    ...jsdocPlugin.configs['flat/recommended'],
+    files: ['src/**/*.ts', 'tests/**/*.ts'],
+  },
   {
     files: ['src/**/*.ts', 'tests/**/*.ts'],
     plugins: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "eslint": "^10.7.0",
+    "eslint-plugin-chai-friendly": "^1.2.1",
     "eslint-plugin-jsdoc": "^63.2.0",
     "eslint-webpack-plugin": "^6.0.0",
     "file-loader": "^6.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       eslint:
         specifier: ^10.7.0
         version: 10.7.0(jiti@2.7.0)
+      eslint-plugin-chai-friendly:
+        specifier: ^1.2.1
+        version: 1.2.1(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-jsdoc:
         specifier: ^63.2.0
         version: 63.2.0(eslint@10.7.0(jiti@2.7.0))
@@ -2081,6 +2084,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-plugin-chai-friendly@1.2.1:
+    resolution: {integrity: sha512-mV3EOJLDr8+L+LS8uCkP711fnNHz+4PsmPyz18xwkvjJwfLRlnx0Eu6CFnb5B+dW5ahoav2jVer2KFYsmIuv3A==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      eslint: '>=3.0.0'
 
   eslint-plugin-jsdoc@63.2.0:
     resolution: {integrity: sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==}
@@ -6065,6 +6074,10 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-chai-friendly@1.2.1(eslint@10.7.0(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.7.0(jiti@2.7.0)
 
   eslint-plugin-jsdoc@63.2.0(eslint@10.7.0(jiti@2.7.0)):
     dependencies:

--- a/frontend/src/ts/resource.ts
+++ b/frontend/src/ts/resource.ts
@@ -1,7 +1,5 @@
 /**
  * Corresponds to a text file
- *
- * @export
  */
 export type Resource = {
   basename: string;
@@ -10,7 +8,5 @@ export type Resource = {
 
 /**
  * Corresponds to a list of Resources
- *
- * @export
  */
 export type ResourceList = Array<Resource>;

--- a/frontend/tests/ts/areas.spec.ts
+++ b/frontend/tests/ts/areas.spec.ts
@@ -2,7 +2,7 @@
 import { expect, use } from 'chai';
 import chaiDom from 'chai-dom';
 
-const chai = use(chaiDom);
+use(chaiDom);
 
 // Import package under test
 import {Area, OutputArea, LabArea, makeLabArea, LabContainer}

--- a/frontend/tests/ts/dom-utils.spec.ts
+++ b/frontend/tests/ts/dom-utils.spec.ts
@@ -1,7 +1,7 @@
 // Import testing libs
 import { expect, use } from 'chai';
 import chaiDom from 'chai-dom';
-const chai = use(chaiDom);
+use(chaiDom);
 
 import {getElemById, getElemsByClass, getElemsByTag}
   from '../../src/ts/dom-utils';

--- a/frontend/tests/ts/download.spec.ts
+++ b/frontend/tests/ts/download.spec.ts
@@ -1,8 +1,7 @@
 import { expect, use } from 'chai';
 import chaiDom from 'chai-dom';
-import chaiAsPromised from 'chai-as-promised';
 
-const chai = use(chaiDom);
+use(chaiDom);
 
 import JSZip from 'jszip';
 import FileSaver from 'file-saver';

--- a/frontend/tests/ts/download.spec.ts
+++ b/frontend/tests/ts/download.spec.ts
@@ -111,7 +111,8 @@ describe('Download', () => {
     });
 
     it('should find builder switches', () => {
-      const parsedSwitches = parseSwitches({Builder: ["test1", "test2"], Compiler: []});
+      const parsedSwitches = parseSwitches(
+          {Builder: ["test1", "test2"], Compiler: []});
       const expectedBuilder = 'for Switches ("Ada") use ("test1", "test2");';
       const expectedCompiler = 'for Switches ("Ada") use ();';
       expect(parsedSwitches['--BUILDER_SWITCHES_PLACEHOLDER--']).to.equal(
@@ -123,7 +124,8 @@ describe('Download', () => {
     });
 
     it('should find compiler switches', () => {
-      const parsedSwitches = parseSwitches({Builder: [], "Compiler": ["test3", "test4"]});
+      const parsedSwitches = parseSwitches(
+          {Builder: [], "Compiler": ["test3", "test4"]});
       const expectedBuilder = 'for Switches ("Ada") use ();';
       const expectedCompiler = 'for Switches ("Ada") use ("test3", "test4");';
       expect(parsedSwitches['--BUILDER_SWITCHES_PLACEHOLDER--']).to.equal(
@@ -212,7 +214,11 @@ describe('Download', () => {
     });
 
     it('should find a main (c file)', () => {
-      const cFile = `#include <stdio.h>\nint main() {\nprintf("Hello, World!");\nreturn 0;\n}`;
+      const cFile = `#include <stdio.h>
+int main() {
+printf("Hello, World!");
+return 0;
+}`;
       const files: ResourceList = [
         {basename: 'other.c', contents: cFile},
         {basename: 'test.ads', contents: ''},
@@ -258,13 +264,15 @@ describe('Download', () => {
   describe('#getGprContents()', () => {
     it('should replace all placeholders', () => {
       const files: ResourceList = [{basename: 'main.adb', contents: ''}];
-      const gpr = getGprContents(files, {Builder: [], Compiler: []}, 'main.adb', false);
+      const gpr =
+          getGprContents(files, {Builder: [], Compiler: []}, 'main.adb', false);
       expect(gpr).to.not.contain('--MAIN_PLACEHOLDER--');
       expect(gpr).to.not.contain('--LANGUAGE_PLACEHOLDER--');
       expect(gpr).to.not.contain('--COMPILER_SWITCHES_PLACEHOLDER--');
       expect(gpr).to.not.contain('--BUILDER_SWITCHES_PLACEHOLDER--');
       expect(gpr).to.not.contain('--');
-      const gpr_spark = getGprContents(files, {Builder: [], Compiler: []}, 'main.adb', true);
+      const gpr_spark =
+          getGprContents(files, {Builder: [], Compiler: []}, 'main.adb', true);
       expect(gpr_spark).to.not.contain('--MAIN_PLACEHOLDER--');
       expect(gpr_spark).to.not.contain('--LANGUAGE_PLACEHOLDER--');
       expect(gpr_spark).to.not.contain('--COMPILER_SWITCHES_PLACEHOLDER--');
@@ -280,7 +288,8 @@ describe('Download', () => {
     let origGenerateAsync: any;
 
     const files: ResourceList = [
-      {basename: 'main.adb', contents: 'procedure Main is begin null; end Main;'},
+      {basename: 'main.adb',
+        contents: 'procedure Main is begin null; end Main;'},
     ];
     const switches: UnparsedSwitches = {Builder: [], Compiler: []};
 
@@ -312,7 +321,8 @@ describe('Download', () => {
       expect(savedFilename).to.equal('MyProject.zip');
     });
 
-    it('should include source, main.gpr, and main.adc in non-SPARK mode', async () => {
+    it('should include source, main.gpr, and main.adc in non-SPARK mode',
+        async () => {
       downloadProject(files, switches, 'main.adb', 'Test', false);
       await new Promise((r) => setTimeout(r, 200));
       expect(capturedFileNames).to.include('main.adb');
@@ -322,7 +332,8 @@ describe('Download', () => {
       expect(capturedFileNames).not.to.include('main_spark.adc');
     });
 
-    it('should also include main_spark.gpr and main_spark.adc in SPARK mode', async () => {
+    it('should also include main_spark.gpr and main_spark.adc in SPARK mode',
+        async () => {
       downloadProject(files, switches, 'main.adb', 'Test', true);
       await new Promise((r) => setTimeout(r, 200));
       expect(capturedFileNames).to.include('main.gpr');

--- a/frontend/tests/ts/download.spec.ts
+++ b/frontend/tests/ts/download.spec.ts
@@ -307,6 +307,7 @@ return 0;
     });
 
     after(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (JSZip.prototype as any).generateAsync = origGenerateAsync;
     });
 

--- a/frontend/tests/ts/editor.spec.ts
+++ b/frontend/tests/ts/editor.spec.ts
@@ -2,7 +2,7 @@
 import { expect, use } from 'chai';
 import chaiDom from 'chai-dom';
 
-const chai = use(chaiDom);
+use(chaiDom);
 
 import * as Ace from 'ace-builds';
 

--- a/frontend/tests/ts/editor.spec.ts
+++ b/frontend/tests/ts/editor.spec.ts
@@ -40,7 +40,8 @@ describe('Editor', () => {
     });
 
     it('should set C_CPP mode for a .c file', () => {
-      const cResource: Resource = {basename: 'main.c', contents: 'int main() { return 0; }'};
+      const cResource: Resource =
+          {basename: 'main.c', contents: 'int main() { return 0; }'};
       inTest.addSession(cResource.basename, cResource.contents);
       inTest.setSession(cResource.basename);
       const session = editor.getSession();

--- a/frontend/tests/ts/scrolltop.spec.ts
+++ b/frontend/tests/ts/scrolltop.spec.ts
@@ -8,7 +8,6 @@ import {scrollTop} from '../../src/ts/scrolltop';
 
 /**
  * Helper function to trigger window event
- *
  * @param {Window} element - The window element
  * @param {string} eventName - The event to do
  */
@@ -20,9 +19,8 @@ function triggerEvent(element: Window, eventName: string): void {
 
 /**
  * Helper function used to override default non implemented version in JSDOM
- *
- * @param {number} x
- * @param {number} y
+ * @param {number} x - The x-coordinate to scroll to
+ * @param {number} y - The y-coordinate to scroll to
  */
 function scrollTo(x: number, y: number): void {
   document.body.scrollTop = y;

--- a/frontend/tests/ts/scrolltop.spec.ts
+++ b/frontend/tests/ts/scrolltop.spec.ts
@@ -2,7 +2,7 @@
 import { expect, use } from 'chai';
 import chaiDom from 'chai-dom';
 
-const chai = use(chaiDom);
+use(chaiDom);
 
 import {scrollTop} from '../../src/ts/scrolltop';
 

--- a/frontend/tests/ts/server.spec.ts
+++ b/frontend/tests/ts/server.spec.ts
@@ -14,10 +14,9 @@ import {CheckOutput, RunProgram} from '../../src/ts/server-types';
 global.WebSocket = WebSocket as unknown as typeof globalThis.WebSocket;
 
 /**
-* Remove all event listeners from the server
-*
-* @param {Server} server - The server to remove the listeners from
-*/
+ * Remove all event listeners from the server
+ * @param {Server} server - The server to remove the listeners from
+ */
 function removeListeners(server: Server): void {
  for (let type in server.listeners) {
    server.listeners[type] = [];

--- a/frontend/tests/ts/server.spec.ts
+++ b/frontend/tests/ts/server.spec.ts
@@ -36,7 +36,8 @@ describe('ServerWorker', () => {
     lab: false,
   };
   let server: Server = new Server(baseURL);
-  let client: ServerWorker = new ServerWorker(baseURL, (data: CheckOutput.FS): boolean => {
+  let client: ServerWorker = new ServerWorker(baseURL,
+      (data: CheckOutput.FS): boolean => {
     cbCount++;
     return data.completed;
   });
@@ -106,7 +107,8 @@ describe('ServerWorker', () => {
     });
 
     it('should throw an exception when AWS rejects the request', async () => {
-      await expect(client.execute(tsData, 2000)).to.be.rejectedWith(expectedErrorMsg);
+      await expect(client.execute(tsData, 2000))
+          .to.be.rejectedWith(expectedErrorMsg);
     });
   });
 
@@ -126,7 +128,8 @@ describe('ServerWorker', () => {
     });
 
     it('should timeout if no response is recieved', async () => {
-      await expect(client.execute(tsData, timeout)).to.be.rejectedWith(expectedErrorMsg);
+      await expect(client.execute(tsData, timeout))
+          .to.be.rejectedWith(expectedErrorMsg);
     });
   });
 });

--- a/frontend/tests/ts/server.spec.ts
+++ b/frontend/tests/ts/server.spec.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import chaiDom from 'chai-dom';
 
 use(chaiAsPromised);
-const chai = use(chaiDom);
+use(chaiDom);
 
 import {Server, WebSocket} from 'mock-socket';
 
@@ -66,7 +66,7 @@ describe('ServerWorker', () => {
 
     before(() => {
       server.on('connection', (socket) => {
-        socket.on('message', (event) => {
+        socket.on('message', (_event) => {
           serverResponses.forEach((msg) => {
             socket.send(JSON.stringify(msg));
           });
@@ -95,7 +95,7 @@ describe('ServerWorker', () => {
 
     before(() => {
       server.on('connection', (socket) => {
-        socket.on('message', (event) => {
+        socket.on('message', (_event) => {
           socket.send(JSON.stringify(serverResponse));
         });
       });
@@ -117,7 +117,7 @@ describe('ServerWorker', () => {
 
     before(() => {
       server.on('connection', (socket) => {
-        socket.on('message', (event) => {});
+        socket.on('message', (_event) => {});
       });
     });
 

--- a/frontend/tests/ts/widget.spec.ts
+++ b/frontend/tests/ts/widget.spec.ts
@@ -222,7 +222,8 @@ describe('Widget', () => {
             'Compiler': ['-gnata', '-gnatX'],
           };
 
-          const request: RunProgram.TS = JSON.parse(receivedMessages[0]) as RunProgram.TS;
+          const request: RunProgram.TS =
+              JSON.parse(receivedMessages[0]) as RunProgram.TS;
 
           expect(request.data.files).to.have.length(1);
           expect(request.data.mode).to.equal('run');
@@ -404,11 +405,13 @@ describe('Widget', () => {
           root.dataset.switches = 'invalid json';
           runButton.click();
           await ServerWorker.delay(250);
-          expect(realDiv.textContent).to.include(Strings.INTERNAL_ERROR_MESSAGE);
+          expect(realDiv.textContent)
+              .to.include(Strings.INTERNAL_ERROR_MESSAGE);
           root.dataset.switches = originalSwitches as string;
         });
 
-        it('should add output line for stdout from a file not in viewMap', async () => {
+        it('should add output line for stdout from a file not in viewMap',
+            async () => {
           const serverResponse: CheckOutput.FS = {
             output: [
               {type: 'stdout', data: 'unknown.adb:1:2: error: test error'},
@@ -482,8 +485,8 @@ describe('Widget', () => {
       });
 
       it('should revert theme setting when user cancels', () => {
-        const themeSetting = getElemById(root.id + '.settings-bar.theme-setting') as
-          HTMLInputElement;
+        const themeSetting = getElemById(
+            root.id + '.settings-bar.theme-setting') as HTMLInputElement;
         window.confirm = (): boolean => false;
         const originalChecked = themeSetting.checked;
         themeSetting.checked = !originalChecked;
@@ -492,8 +495,8 @@ describe('Widget', () => {
       });
 
       it('should apply dark theme and reload when user confirms', () => {
-        const themeSetting = getElemById(root.id + '.settings-bar.theme-setting') as
-          HTMLInputElement;
+        const themeSetting = getElemById(
+            root.id + '.settings-bar.theme-setting') as HTMLInputElement;
         window.confirm = (): boolean => true;
         themeSetting.checked = true;
         try {
@@ -511,11 +514,12 @@ describe('Widget', () => {
           getElemById(root.id + '.settings-bar.compiler-switches');
       });
 
-      it('should deactivate mutually exclusive switches when one is checked', () => {
-        const gnato = document.getElementById(
-            root.id + '.settings-bar.compiler-switches.-gnato') as HTMLInputElement;
-        const gnato0 = document.getElementById(
-            root.id + '.settings-bar.compiler-switches.-gnato0') as HTMLInputElement;
+      it('should deactivate mutually exclusive switches when one is checked',
+          () => {
+        const gnatoId = root.id + '.settings-bar.compiler-switches.-gnato';
+        const gnato = document.getElementById(gnatoId) as HTMLInputElement;
+        const gnato0Id = root.id + '.settings-bar.compiler-switches.-gnato0';
+        const gnato0 = document.getElementById(gnato0Id) as HTMLInputElement;
         gnato.checked = true;
         gnato0.checked = true;
         triggerEvent(gnato0, 'change');
@@ -547,7 +551,8 @@ describe('Widget', () => {
             'compiler-switch-help-info')[0] as HTMLElement;
         const firstEntry = compilerSwitchesSetting.getElementsByClassName(
             'compiler-switch-entry')[0] as HTMLElement;
-        const b = firstEntry.getElementsByTagName('button')[0] as HTMLButtonElement;
+        const b =
+            firstEntry.getElementsByTagName('button')[0] as HTMLButtonElement;
         b.click();
         expect(d.classList.contains('disabled')).to.be.false;
         expect(d.querySelector('b')).to.not.be.null;
@@ -582,7 +587,8 @@ describe('Widget', () => {
         const outputDiv = getElemById(root.id + '.output-area');
         dlButton.click();
         await ServerWorker.delay(100);
-        expect(outputDiv.textContent).to.include(Strings.INTERNAL_ERROR_MESSAGE);
+        expect(outputDiv.textContent)
+            .to.include(Strings.INTERNAL_ERROR_MESSAGE);
         root.dataset.switches = originalSwitches as string;
       });
     });
@@ -781,7 +787,8 @@ describe('Widget', () => {
     });
 
     it('should populate the code-block-info output element', () => {
-      const cbiContents = getElemById(root.id + '.code_block_info.run info.contents');
+      const cbiContents =
+          getElemById(root.id + '.code_block_info.run info.contents');
       expect(cbiContents.innerText).to.include('Hello from run output!');
     });
   });

--- a/frontend/tests/ts/widget.spec.ts
+++ b/frontend/tests/ts/widget.spec.ts
@@ -2,11 +2,11 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiDom from 'chai-dom';
-import {Client, Server, WebSocket} from 'mock-socket';
+import {Server, WebSocket} from 'mock-socket';
 import FileSaver from 'file-saver';
 
-// const chai = use(chaiDom);
-const chai = use(chaiAsPromised);
+use(chaiDom);
+use(chaiAsPromised);
 
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
@@ -139,7 +139,6 @@ describe('Widget', () => {
       let buttonGroup: HTMLElement;
       let outputDiv: HTMLElement;
       let runButton: HTMLButtonElement;
-      const identifier = 123;
 
       before(() => {
         buttonGroup = getElemById(root.id + '.button-group');
@@ -147,7 +146,7 @@ describe('Widget', () => {
 
         // stub scrollIntoView function beacuse JSDOM doesn't have it
         // eslint-disable-next-line max-len
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
         window.HTMLElement.prototype.scrollIntoView = (arg: any): void => {};
       });
 
@@ -264,7 +263,6 @@ describe('Widget', () => {
         let fakeDiv: HTMLDivElement;
         let fakeOA: OutputArea;
         let realDiv: HTMLElement;
-        let receivedMessages: Array<string> = [];
 
         beforeEach(() => {
           fakeDiv = document.createElement('div') as HTMLDivElement;
@@ -281,7 +279,7 @@ describe('Widget', () => {
             "requestId": "abc_-=2"
           };
           server.on('connection', (socket) => {
-            socket.on('message', (event) => {
+            socket.on('message', (_event) => {
               socket.send(JSON.stringify(serverResponse));
             });
           });
@@ -313,7 +311,7 @@ describe('Widget', () => {
             }
           ];
           server.on('connection', (socket) => {
-            socket.on('message', (event) => {
+            socket.on('message', (_event) => {
               serverResponses.forEach((msg) => {
                 socket.send(JSON.stringify(msg));
               });
@@ -347,7 +345,7 @@ describe('Widget', () => {
             }
           ];
           server.on('connection', (socket) => {
-            socket.on('message', (event) => {
+            socket.on('message', (_event) => {
               serverResponses.forEach((msg) => {
                 socket.send(JSON.stringify(msg));
               });
@@ -384,7 +382,7 @@ describe('Widget', () => {
             }
           ];
           server.on('connection', (socket) => {
-            socket.on('message', (event) => {
+            socket.on('message', (_event) => {
               serverResponses.forEach((msg) => {
                 socket.send(JSON.stringify(msg));
               });
@@ -640,7 +638,6 @@ describe('Widget', () => {
       });
 
       describe('Normal Behavior', () => {
-        const identifier = 123;
         const consoleMsg = 'General message';
         let receivedMessages: Array<string> = [];
 

--- a/frontend/tests/ts/widget.spec.ts
+++ b/frontend/tests/ts/widget.spec.ts
@@ -32,7 +32,6 @@ const __dirname = dirname(__filename);
 
 /**
  * Helper function to fill DOM from a file
- *
  * @param {string} filename - The filename to use
  */
 function fillDOM(filename: string): void {
@@ -53,7 +52,6 @@ function clearDOM(): void {
 
 /**
  * Helper function to trigger an event
- *
  * @param {HTMLElement} element - The element to trigger the event on
  * @param {string} eventName - The event name to trigger
  */
@@ -64,10 +62,9 @@ function triggerEvent(element: HTMLElement, eventName: string): void {
 }
 
 /**
-* Remove all event listeners from the server
-*
-* @param {Server} server - The server to remove the listeners from
-*/
+ * Remove all event listeners from the server
+ * @param {Server} server - The server to remove the listeners from
+ */
 function removeListeners(server: Server): void {
  for (let type in server.listeners) {
    server.listeners[type] = [];


### PR DESCRIPTION
## Summary

`pnpm run eslint` went from 276 problems (71 errors, 205 warnings) to 0,
and is now enforced in CI so regressions get caught instead of
accumulating silently again.

- `eslint.config.js` had an unscoped jsdoc rule block, so ESLint was
  linting `tests/html/` — a gitignored, regenerated Sphinx build output
  directory containing furo theme JavaScript, not project code. That
  accounted for 93% of all warnings. Scoped it to match the sibling
  TypeScript config block.
- Added `eslint-plugin-chai-friendly` so chai assertions
  (`expect(x).to.be.true`) aren't misread as dead code by
  `no-unused-expressions` (26 false-positive errors).
- Fixed the remaining 71 real errors and 15 real warnings: dead
  variables/imports (including one chai-dom registration that was
  silently relying on Mocha's alphabetical spec-file load order),
  unwrapped long lines, a missing `no-explicit-any` suppression
  comment, and jsdoc formatting issues.
- Added `.github/workflows/eslint.js.yml`, a fast dedicated lint check
  (mirrors `code-projects-type-check.yml`'s shape) rather than folding
  it into `typescript-tests.js.yml`, which installs a full GNAT/Sphinx
  toolchain unrelated to a lint check.

## Test plan

- [x] `pnpm run eslint` exits 0
- [x] `pnpm run test` — 126 passing, coverage unchanged (99.94%)
- [x] `pnpm install --frozen-lockfile` succeeds against the updated lockfile
- [x] New `ESLint` CI check passes on this PR
